### PR TITLE
Fix bug when creating object using ruby library

### DIFF
--- a/ruby/lib/simperium.rb
+++ b/ruby/lib/simperium.rb
@@ -236,7 +236,7 @@ module Simperium
         
         def post(item, data, options={})
             defaults = {:version=>nil, :ccid=>nil, :include_response=>false, :replace=>false}
-            unless options.empty?
+            unless options.nil? || options.empty?
                 options = defaults.merge(options)
             else
                 options = defaults


### PR DESCRIPTION
Creating an object was impossible because `new` sends `nil` as options hash and `post` tested that for `blank?` which nil doesn't have
