### PR TITLE
Issue #110: Updates background fetch API

### DIFF
--- a/Simperium/SPBucket+Internals.h
+++ b/Simperium/SPBucket+Internals.h
@@ -10,7 +10,7 @@
 
 
 
-typedef void (^SPBucketForceSyncCompletion)(void);
+typedef void (^SPBucketForceSyncCompletion)(BOOL signatureUpdated);
 
 #pragma mark ====================================================================================
 #pragma mark SPBucket: Private Methods
@@ -33,6 +33,7 @@ typedef void (^SPBucketForceSyncCompletion)(void);
 @property (nonatomic, strong) SPIndexProcessor				*indexProcessor;
 @property (nonatomic, strong) dispatch_queue_t				processorQueue;
 @property (nonatomic,   copy) SPBucketForceSyncCompletion	forceSyncCompletion;
+@property (nonatomic,   copy) NSString						*forceSyncSignature;
 
 - (id)initWithSchema:(SPSchema *)aSchema
              storage:(id<SPStorageProvider>)aStorage
@@ -45,7 +46,8 @@ relationshipResolver:(SPRelationshipResolver *)resolver
 - (void)unloadAllObjects;
 - (void)resolvePendingRelationshipsToKeys:(NSSet *)keys;
 - (void)forceSyncWithCompletion:(SPBucketForceSyncCompletion)completion;
-- (void)bucketDidSync;
+- (BOOL)isForceSyncPending;
+- (void)signalForceSyncComplete;
 - (NSDictionary*)exportStatus;
 
 @end

--- a/Simperium/SPChangeProcessor.m
+++ b/Simperium/SPChangeProcessor.m
@@ -484,10 +484,14 @@ static int const SPChangeProcessorMaxPendingChanges	= 200;
     
         [self.changesPending save];
         
-        // Signal that the bucket was sync'ed. We need this, in case the sync was manually triggered
-        if (self.changesPending.count == 0) {
-            [bucket bucketDidSync];
+        // Signal that synthe bucket has been sync'ed (If Needed!)
+        if (![bucket isForceSyncPending] || self.changesPending.count) {
+            return;
         }
+        
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [bucket signalForceSyncComplete];
+        });
     }
 }
 

--- a/Simperium/Simperium.h
+++ b/Simperium/Simperium.h
@@ -86,9 +86,9 @@ typedef NS_ENUM(NSInteger, SPSimperiumErrors) {
 // (you can also just save your context and Simperium will see the changes).
 - (BOOL)save;
 
-// Force Simperium to sync all its buckets. Success return value will be false if the timeout is reached, and the sync wasn't completed.
-typedef void (^SimperiumForceSyncCompletion)(BOOL success);
-- (void)forceSyncWithTimeout:(NSTimeInterval)timeoutSeconds completion:(SimperiumForceSyncCompletion)completion;
+// Support for iOS Background Fetch. 'syncedNewData' flag will be True if new data was effectively retrieved.
+typedef void (^SimperiumBackgroundFetchCompletion)(BOOL syncedNewData);
+- (void)backgroundFetchWithCompletion:(SimperiumBackgroundFetchCompletion)completion;
 
 // Get a particular bucket (which, for Core Data, corresponds to a particular Entity name in your model).
 // Once you have a bucket instance, you can set a SPBucketDelegate to react to changes.


### PR DESCRIPTION
Background Fetch API has been updated. Usage should be as follows:

```
- (void)application:(UIApplication *)application performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
{
    [self.simperium backgroundFetchWithCompletion:^(UIBackgroundFetchResult result) {

        completionHandler(result);
    }];
}
```
