### PR TITLE
optimized most time consuming tasks during bulk operations

### DIFF
--- a/Simperium/SPChangeProcessor.h
+++ b/Simperium/SPChangeProcessor.h
@@ -59,4 +59,6 @@ typedef NS_ENUM(NSInteger, SPProcessorErrors) {
 
 - (NSArray *)exportPendingChanges;
 
+- (void)asyncNumChangesPending:(void(^)(NSInteger))completion limit:(NSInteger)limit;
+
 @end

--- a/Simperium/SPChangeProcessor.m
+++ b/Simperium/SPChangeProcessor.m
@@ -476,9 +476,7 @@ static int const SPChangeProcessorMaxPendingChanges	= 200;
             // Persist LastChangeSignature: do it inside the loop in case something happens to abort the loop
             NSString *changeVersion = change[CH_CHANGE_VERSION];
             
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [bucket setLastChangeSignature: changeVersion];
-            });
+            [bucket setLastChangeSignature: changeVersion];
         }
     
         [self.changesPending save];
@@ -762,6 +760,13 @@ static int const SPChangeProcessorMaxPendingChanges	= 200;
 	return (self.changesPending.count >= SPChangeProcessorMaxPendingChanges);
 }
 
+#pragma mark ====================================================================================
+#pragma mark Optimized methods for batch processing
+#pragma mark ====================================================================================
+
+- (void)asyncNumChangesPending:(void(^)(NSInteger))completion limit:(NSInteger)limit {
+    [self.changesPending asyncCountWithCompletion:completion limit:limit];
+}
 
 #pragma mark ====================================================================================
 #pragma mark Private Helpers: Changeset Generation + metadata

--- a/Simperium/SPPersistentMutableDictionary.h
+++ b/Simperium/SPPersistentMutableDictionary.h
@@ -19,6 +19,7 @@
 @property (nonatomic, strong, readonly) NSString *label;
 
 - (NSInteger)count;
+- (void)asyncCountWithCompletion:(void (^)(NSInteger))completion limit:(NSInteger)limit;
 - (BOOL)containsObjectForKey:(id)aKey;
 
 - (id)objectForKey:(NSString*)aKey;


### PR DESCRIPTION
After profiling some bulk delete operations, I identified the most time consuming operations and:
- optimized the count operations by using a fetchLimit
- created some asynchronous count operation to not block the main thread with performBlockAndWait
