### PR TITLE
NetworkEnabled should start managers if the user is authenticated

### DIFF
--- a/Simperium/Simperium.m
+++ b/Simperium/Simperium.m
@@ -237,8 +237,10 @@ static SPLogLevels logLevel                     = SPLogLevelsInfo;
     }
     
     _networkEnabled = enabled;
-    if (enabled) {
+    if (enabled && self.authenticationEnabled) {
         [self authenticateIfNecessary];
+    } else if (enabled && self.user.authenticated) {
+        [self startNetworkManagers];
     } else {
         [self stopNetworkManagers];
     }


### PR DESCRIPTION
Updates networkEnabled setter behavior:
- If the user was already authenticated, we should start the network managers right away. That's the scenario involved in _authenticateWithToken_ call.
