### PR TITLE
Add optional forgot password link

### DIFF
--- a/Simperium.xcodeproj/project.pbxproj
+++ b/Simperium.xcodeproj/project.pbxproj
@@ -163,6 +163,8 @@
 		46EE3D41171C975D00E6F0A5 /* SimperiumComplexTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 46EE3D40171C975D00E6F0A5 /* SimperiumComplexTests.m */; };
 		46EE3D44171C978E00E6F0A5 /* SimperiumAuxiliaryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 46EE3D43171C978D00E6F0A5 /* SimperiumAuxiliaryTests.m */; };
 		46EE3D57171D0C8E00E6F0A5 /* SimperiumErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 46EE3D56171D0C8E00E6F0A5 /* SimperiumErrorTests.m */; };
+		79343B041A28552B006715C2 /* SPForgotPWViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 79343B021A28552B006715C2 /* SPForgotPWViewController.h */; };
+		79343B051A28552B006715C2 /* SPForgotPWViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 79343B031A28552B006715C2 /* SPForgotPWViewController.m */; };
 		797D26FE19F1B72700DEF569 /* SSKeychain.h in Headers */ = {isa = PBXBuildFile; fileRef = 797D26FA19F1B72700DEF569 /* SSKeychain.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		797D26FF19F1B72700DEF569 /* SSKeychain.m in Sources */ = {isa = PBXBuildFile; fileRef = 797D26FB19F1B72700DEF569 /* SSKeychain.m */; };
 		797D270019F1B72700DEF569 /* SSKeychainQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = 797D26FC19F1B72700DEF569 /* SSKeychainQuery.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -407,6 +409,8 @@
 		46EE3D40171C975D00E6F0A5 /* SimperiumComplexTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SimperiumComplexTests.m; sourceTree = "<group>"; };
 		46EE3D43171C978D00E6F0A5 /* SimperiumAuxiliaryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SimperiumAuxiliaryTests.m; sourceTree = "<group>"; };
 		46EE3D56171D0C8E00E6F0A5 /* SimperiumErrorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SimperiumErrorTests.m; sourceTree = "<group>"; };
+		79343B021A28552B006715C2 /* SPForgotPWViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPForgotPWViewController.h; sourceTree = "<group>"; };
+		79343B031A28552B006715C2 /* SPForgotPWViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPForgotPWViewController.m; sourceTree = "<group>"; };
 		797D26FA19F1B72700DEF569 /* SSKeychain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SSKeychain.h; sourceTree = "<group>"; };
 		797D26FB19F1B72700DEF569 /* SSKeychain.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SSKeychain.m; sourceTree = "<group>"; };
 		797D26FC19F1B72700DEF569 /* SSKeychainQuery.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SSKeychainQuery.h; sourceTree = "<group>"; };
@@ -851,6 +855,8 @@
 				466EB41317BC45F5005F7599 /* SPAuthenticationValidator.m */,
 				E265DBCE17CD3E0A00070550 /* SPTOSViewController.h */,
 				E265DBCF17CD3E0A00070550 /* SPTOSViewController.m */,
+				79343B021A28552B006715C2 /* SPForgotPWViewController.h */,
+				79343B031A28552B006715C2 /* SPForgotPWViewController.m */,
 			);
 			name = Authentication;
 			sourceTree = "<group>";
@@ -988,6 +994,7 @@
 				264CD942135DFE6D00C51BAD /* SPGhost.h in Headers */,
 				264CD944135DFE6D00C51BAD /* SPMember.h in Headers */,
 				264CD996135DFE7E00C51BAD /* DiffMatchPatch.h in Headers */,
+				79343B041A28552B006715C2 /* SPForgotPWViewController.h in Headers */,
 				264CD999135DFE7E00C51BAD /* DiffMatchPatchCFUtilities.h in Headers */,
 				264CD99A135DFE7E00C51BAD /* MinMaxMacros.h in Headers */,
 				264CD99B135DFE7E00C51BAD /* NSMutableDictionary+DMPExtensions.h in Headers */,
@@ -1273,6 +1280,7 @@
 				267CE8FF156C0FD20028801C /* SPBucket.m in Sources */,
 				24A73F5717E250E0000CA275 /* SPPersistentMutableDictionary.m in Sources */,
 				267CE902156C0FD20028801C /* SPDiffer.m in Sources */,
+				79343B051A28552B006715C2 /* SPForgotPWViewController.m in Sources */,
 				267CE904156C0FD20028801C /* SPJSONStorage.m in Sources */,
 				797D26FF19F1B72700DEF569 /* SSKeychain.m in Sources */,
 				267CE906156C0FD20028801C /* SPObject.m in Sources */,

--- a/Simperium/SPAuthenticationConfiguration.h
+++ b/Simperium/SPAuthenticationConfiguration.h
@@ -13,6 +13,7 @@
 @property (nonatomic, copy) NSString *regularFontName;
 @property (nonatomic, copy) NSString *mediumFontName;
 @property (nonatomic, copy) NSString *logoImageName;
+@property (nonatomic, readwrite, assign) BOOL *showForgotPasswordButton;
 
 #if TARGET_OS_IPHONE
 #else

--- a/Simperium/SPAuthenticationConfiguration.h
+++ b/Simperium/SPAuthenticationConfiguration.h
@@ -14,6 +14,7 @@
 @property (nonatomic, copy) NSString *mediumFontName;
 @property (nonatomic, copy) NSString *logoImageName;
 @property (nonatomic, readwrite, assign) BOOL *showForgotPasswordButton;
+@property (nonatomic, readwrite, assign) BOOL *showTOSButton;
 
 #if TARGET_OS_IPHONE
 #else

--- a/Simperium/SPAuthenticationConfiguration.m
+++ b/Simperium/SPAuthenticationConfiguration.m
@@ -33,6 +33,7 @@ static SPAuthenticationConfiguration *gInstance = NULL;
     if (self) {
         _regularFontName = @"HelveticaNeue";
         _mediumFontName = @"HelveticaNeue-Medium";
+        _showTOSButton = YES;
         
 #if TARGET_OS_IPHONE
 #else

--- a/Simperium/SPAuthenticationViewController.m
+++ b/Simperium/SPAuthenticationViewController.m
@@ -216,7 +216,9 @@ static CGFloat const SPAuthenticationFieldPaddingX = 10.0;
     UIView *footerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, self.changeButton.frame.size.height + self.changeButton.frame.origin.y)];
     footerView.contentMode = UIViewContentModeTopLeft;
     [footerView setUserInteractionEnabled:YES];
-    [footerView addSubview:_termsButton];
+    if ([[SPAuthenticationConfiguration sharedInstance] showTOSButton]) {
+        [footerView addSubview:_termsButton];
+    }
     if ([[SPAuthenticationConfiguration sharedInstance] showForgotPasswordButton]) {
         [footerView addSubview:_forgotPasswordButton];
     }

--- a/Simperium/SPAuthenticationViewController.m
+++ b/Simperium/SPAuthenticationViewController.m
@@ -15,6 +15,7 @@
 #import "SPAuthenticationConfiguration.h"
 #import "SPAuthenticationValidator.h"
 #import "SPTOSViewController.h"
+#import "SPForgotPWViewController.h"
 
 
 
@@ -42,6 +43,7 @@ static CGFloat const SPAuthenticationFieldPaddingX = 10.0;
 @property (nonatomic, strong) SPAuthenticationButton    *actionButton;
 @property (nonatomic, strong) SPAuthenticationButton    *changeButton;
 @property (nonatomic, strong) UIButton                  *termsButton;
+@property (nonatomic, strong) UIButton					*forgotPasswordButton;
 
 @property (nonatomic, strong) UITextField               *usernameField;
 @property (nonatomic, strong) UITextField               *passwordField;
@@ -97,6 +99,7 @@ static CGFloat const SPAuthenticationFieldPaddingX = 10.0;
     self.changeButton.detailTitleLabel.text = changeDetailTitle.uppercaseString;
 
     self.termsButton.hidden = _signingIn;
+    self.forgotPasswordButton.hidden = !_signingIn;
 }
 
 - (void)viewDidLoad {
@@ -157,7 +160,24 @@ static CGFloat const SPAuthenticationFieldPaddingX = 10.0;
     _termsButton.titleLabel.font = [UIFont fontWithName:configuration.mediumFontName size:10.0];
     _termsButton.frame = CGRectMake(10.0, 0.0, self.tableView.frame.size.width-20.0, 24.0);
     _termsButton.autoresizingMask = UIViewAutoresizingFlexibleWidth;
-    [_termsButton setAttributedTitle:termsTitle forState:UIControlStateNormal];;
+    [_termsButton setAttributedTitle:termsTitle forState:UIControlStateNormal];
+    
+    // Forgot Password String
+	NSDictionary *forgotPasswordAttributes = @{
+        NSForegroundColorAttributeName: [greyColor colorWithAlphaComponent:0.4]
+    };
+	
+	NSString *forgotPasswordText = NSLocalizedString(@"Forgot password? »", @"Forgot password Button Text");
+    NSMutableAttributedString *forgotPasswordTitle = [[NSMutableAttributedString alloc] initWithString:[forgotPasswordText uppercaseString] attributes:forgotPasswordAttributes];
+	
+	// Forgot Password Button
+    self.forgotPasswordButton = [UIButton buttonWithType:UIButtonTypeCustom];
+	[_forgotPasswordButton addTarget:self action:@selector(forgotPasswordAction:) forControlEvents:UIControlEventTouchUpInside];
+    _forgotPasswordButton.titleEdgeInsets = UIEdgeInsetsMake(3, 0, 0, 0);
+    _forgotPasswordButton.titleLabel.font = [UIFont fontWithName:configuration.mediumFontName size:10.0];
+    _forgotPasswordButton.frame = CGRectMake(10.0, 0.0, self.tableView.frame.size.width-20.0, 24.0);
+	_forgotPasswordButton.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+    [_forgotPasswordButton setAttributedTitle:forgotPasswordTitle forState:UIControlStateNormal];
     
     // Action
     self.actionButton = [[SPAuthenticationButton alloc] initWithFrame:CGRectMake(0, 30.0, self.view.frame.size.width, 44)];
@@ -197,6 +217,9 @@ static CGFloat const SPAuthenticationFieldPaddingX = 10.0;
     footerView.contentMode = UIViewContentModeTopLeft;
     [footerView setUserInteractionEnabled:YES];
     [footerView addSubview:_termsButton];
+    if ([[SPAuthenticationConfiguration sharedInstance] showForgotPasswordButton]) {
+        [footerView addSubview:_forgotPasswordButton];
+    }
     [footerView addSubview:_actionButton];
     [footerView addSubview:_changeButton];
     footerView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
@@ -514,6 +537,18 @@ static CGFloat const SPAuthenticationFieldPaddingX = 10.0;
     SPTOSViewController *vc = [[SPTOSViewController alloc] init];
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:vc];
     
+    if (self.navigationController) {
+        [self.navigationController presentViewController:navController animated:YES completion:nil];
+    } else {
+        [self presentViewController:navController animated:YES completion:nil];
+    }
+}
+
+- (void)forgotPasswordAction:(id)sender {
+   
+   SPForgotPWViewController *vc = [[SPForgotPWViewController alloc] init];
+   UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:vc];
+   
     if (self.navigationController) {
         [self.navigationController presentViewController:navController animated:YES completion:nil];
     } else {

--- a/Simperium/SPForgotPWViewController.h
+++ b/Simperium/SPForgotPWViewController.h
@@ -1,0 +1,17 @@
+//
+//  SPForgotPWViewController.h
+//  Simperium
+//
+//  Created by Patrick Vink on 11/28/14.
+//  Copyright (c) 2013 Simperium. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface SPForgotPWViewController : UIViewController <UIWebViewDelegate> {
+    
+    UIWebView *webView;
+    UIActivityIndicatorView *activityIndicator;
+}
+
+@end

--- a/Simperium/SPForgotPWViewController.m
+++ b/Simperium/SPForgotPWViewController.m
@@ -1,0 +1,80 @@
+//
+//  SPForgotPWViewController.m
+//  Simperium
+//
+//  Created by Patrick Vink on 11/28/14.
+//  Copyright (c) 2013 Simperium. All rights reserved.
+//
+
+#import "SPForgotPWViewController.h"
+#import "SPLogger.h"
+
+#pragma mark ====================================================================================
+#pragma mark Constants
+#pragma mark ====================================================================================
+
+static SPLogLevels logLevel     = SPLogLevelsInfo;
+
+@interface SPForgotPWViewController ()
+
+@end
+
+@implementation SPForgotPWViewController
+
+- (void)loadView {
+    
+    if (!webView) {
+        webView = [[UIWebView alloc] init];
+        webView.delegate = self;
+        self.view = webView;
+    }
+}
+
+- (void)dismissAction:(id)sender {
+    
+    [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+    
+    activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
+    [activityIndicator hidesWhenStopped];
+    UIBarButtonItem *activityContainer = [[UIBarButtonItem alloc] initWithCustomView:activityIndicator];
+    self.navigationItem.leftBarButtonItem = activityContainer;
+    
+    self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(dismissAction:)];
+    
+    NSString *forgotPWURL = NSLocalizedString(@"Forgot Password URL", @"Using this localized string you can set your own password per language");
+    
+    if (![self isValidURL:forgotPWURL]) {
+        SPLogInfo(@"URL for forgot password is not valid... Please use the localized string 'Forgot Password URL', to set the correct forgot password link per language");
+        // Dummy link to show Simperium 404 page
+        forgotPWURL = @"https://simperium.com/404.html";
+    }
+    
+    NSURLRequest *request = [[NSURLRequest alloc] initWithURL:[NSURL URLWithString:forgotPWURL]];
+    [webView loadRequest:request];
+}
+
+- (BOOL)isValidURL:(NSString *)urlString{
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:urlString]];
+    return [NSURLConnection canHandleRequest:request];
+}
+
+#pragma mark UIWebViewDelegate Methods
+
+- (void)webViewDidStartLoad:(UIWebView *)webView {
+    
+    [activityIndicator startAnimating];
+}
+
+- (void)webViewDidFinishLoad:(UIWebView *)webView {
+    
+    [activityIndicator stopAnimating];
+}
+
+
+@end

--- a/Simperium/SPTOSViewController.m
+++ b/Simperium/SPTOSViewController.m
@@ -6,8 +6,6 @@
 //  Copyright (c) 2013 Simperium. All rights reserved.
 //
 
-NSString *const TOSUrl = @"http://simperium.com/tos/";
-
 #import "SPTOSViewController.h"
 
 @interface SPTOSViewController ()
@@ -42,16 +40,23 @@ NSString *const TOSUrl = @"http://simperium.com/tos/";
     
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(dismissAction:)];
     
-    NSURLRequest *request = [[NSURLRequest alloc] initWithURL:[NSURL URLWithString:TOSUrl]];
+    NSString *termsURL = NSLocalizedString(@"TOS URL", @"Using this localized string you can set your own TOS per language");
+    
+    if (![self isValidURL:termsURL]) {
+        // Show default Simperium TOS
+        termsURL = @"http://simperium.com/tos/";
+    }
+    
+    NSURLRequest *request = [[NSURLRequest alloc] initWithURL:[NSURL URLWithString:termsURL]];
     [webView loadRequest:request];
 }
 
-#pragma mark UIWebViewDelegate Methods
-
-- (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType {
-    
-    return [[NSString stringWithFormat:@"%@", request.URL] isEqualToString:TOSUrl];
+- (BOOL)isValidURL:(NSString *)urlString{
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:urlString]];
+    return [NSURLConnection canHandleRequest:request];
 }
+
+#pragma mark UIWebViewDelegate Methods
 
 - (void)webViewDidStartLoad:(UIWebView *)webView {
     


### PR DESCRIPTION
With this PR, you can add an optional Forgot Password button to the Login ViewController (Ref: #155). This button is only shown when is explicitly activated and an valid URL is supplied using a localized string. By using the localized string, you can set specific URL's per language. This forgot password button switches place with the TOS button, so it doesn't take extra space in the Login ViewController.

To activate the button use: `[SPAuthenticationConfiguration sharedInstance].showForgotPasswordButton = YES;`
The localized string that should be used for the Forgot Password URL is: `"Forgot Password URL"`

This PR also changes the TOS URL to a localized custom TOS URL using: `"TOS URL"`. if it's not supplied and/or valid, it uses the default Simperium TOS.

Hope it helps!

Regards Patrick