### PR TITLE
Implements Previous Username

### DIFF
--- a/Simperium-OSX/Simperium-OSX/SPAuthenticationWindowController.m
+++ b/Simperium-OSX/Simperium-OSX/SPAuthenticationWindowController.m
@@ -98,6 +98,10 @@ static CGFloat const SPAuthenticationProgressSize       = 20.0f;
         self.usernameField = [[SPAuthenticationTextField alloc] initWithFrame:NSMakeRect(SPAuthenticationFieldPaddingX, markerY - SPAuthenticationRowSize, SPAuthenticationFieldWidth, SPAuthenticationFieldHeight) secure:NO];
         
         [self.usernameField setPlaceholderString:NSLocalizedString(@"Email Address", @"Placeholder text for login field")];
+        if (_signingIn && [[SPAuthenticationConfiguration sharedInstance] previousUsernameEnabled]) {
+            // Get previous username, to display as last used username in authentication view
+            [self.usernameField setStringValue:[[NSUserDefaults standardUserDefaults] objectForKey:@"SPUsernamePrevious"]];
+        }
         self.usernameField.delegate = self;
         [authView addSubview:self.usernameField];
         

--- a/Simperium/SPAuthenticationConfiguration.h
+++ b/Simperium/SPAuthenticationConfiguration.h
@@ -22,6 +22,8 @@
 @property (nonatomic, assign, readwrite) NSString   *forgotPasswordURL;
 @property (nonatomic, assign, readwrite) NSString   *termsOfServiceURL;
 
+@property (nonatomic, assign, readwrite) BOOL       previousUsernameEnabled;
+
 #if !TARGET_OS_IPHONE
 @property (nonatomic, strong) NSColor *controlColor;
 #endif

--- a/Simperium/SPAuthenticationConfiguration.m
+++ b/Simperium/SPAuthenticationConfiguration.m
@@ -44,9 +44,10 @@ static NSString *SPAuthenticationTestString             = @"Testyj";
 - (instancetype)init {
     self = [super init];
     if (self) {
-        _regularFontName    = SPAuthenticationDefaultRegularFontName;
-        _mediumFontName     = SPAuthenticationDefaultMediumFontName;
-        _termsOfServiceURL  = SPTermsOfServiceURL;
+        _regularFontName            = SPAuthenticationDefaultRegularFontName;
+        _mediumFontName             = SPAuthenticationDefaultMediumFontName;
+        _termsOfServiceURL          = SPTermsOfServiceURL;
+        _previousUsernameEnabled    = YES;
         
 #if !TARGET_OS_IPHONE
         _controlColor       = [NSColor colorWithCalibratedRed:65.f/255.f green:137.f/255.f blue:199.f/255.f alpha:1.0];

--- a/Simperium/SPAuthenticationViewController.m
+++ b/Simperium/SPAuthenticationViewController.m
@@ -177,6 +177,10 @@ static NSString *SPAuthenticationConfirmCellIdentifier      = @"ConfirmCellIdent
     NSString *usernameText = @"email@email.com";
     self.usernameField = [self textFieldWithPlaceholder:usernameText secure:NO];
     _usernameField.keyboardType = UIKeyboardTypeEmailAddress;
+    if (_signingIn && [[SPAuthenticationConfiguration sharedInstance] previousUsernameEnabled]) {
+        // Get previous username, to display as last used username in authentication view
+        _usernameField.text = [[NSUserDefaults standardUserDefaults] objectForKey:@"SPUsernamePrevious"];
+    }
     
     // Password Field
     NSString *passwordText = NSLocalizedString(@"Password", @"Hint displayed in the password field");

--- a/Simperium/SPWebViewController.m
+++ b/Simperium/SPWebViewController.m
@@ -7,15 +7,6 @@
 //
 
 #import "SPWebViewController.h"
-#import "SPLogger.h"
-
-
-
-#pragma mark ====================================================================================
-#pragma mark Constants
-#pragma mark ====================================================================================
-
-static SPLogLevels logLevel = SPLogLevelsInfo;
 
 
 #pragma mark ====================================================================================

--- a/Simperium/Simperium.m
+++ b/Simperium/Simperium.m
@@ -744,6 +744,10 @@ static SPLogLevels logLevel                     = SPLogLevelsInfo;
 
 - (void)authenticationDidSucceedForUsername:(NSString *)username token:(NSString *)token {
     
+    // Save username as previous username, this username is used to display as last username in authentication views
+    [[NSUserDefaults standardUserDefaults] setObject:username forKey:@"SPUsernamePrevious"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+    
     // It's now safe to start the network managers
     [self startNetworkManagers];
     

--- a/Simperium/Simperium.m
+++ b/Simperium/Simperium.m
@@ -78,7 +78,6 @@ static SPLogLevels logLevel                     = SPLogLevelsInfo;
         self.validatesObjects               = YES;
         self.authenticationEnabled          = YES;
         self.dynamicSchemaEnabled           = YES;
-        self.authenticationEnabled          = YES;
         self.buckets                        = [NSMutableDictionary dictionary];
         
         SPReachability *reachability        = [SPReachability reachabilityForInternetConnection];

--- a/Simperium/Simperium.m
+++ b/Simperium/Simperium.m
@@ -595,9 +595,6 @@ static SPLogLevels logLevel                     = SPLogLevelsInfo;
     [self.authenticator reset];
     self.user = nil;
     
-    // We just logged out. Let's display SignIn fields next time!
-    self.shouldSignIn = YES;
-    
     // Reset the network manager and processors; any enqueued tasks will get skipped
     self.logoutInProgress = YES;
     
@@ -813,6 +810,11 @@ static SPLogLevels logLevel                     = SPLogLevelsInfo;
 }
 
 - (void)openAuthViewControllerAnimated:(BOOL)animated {
+    // Get previous username, if available the sign-in view should be set as default
+    if ([[NSUserDefaults standardUserDefaults] objectForKey:@"SPUsernamePrevious"]) {
+        self.shouldSignIn = YES;
+    }
+
 #if TARGET_OS_IPHONE
     if ([self isAuthVisible]) {
         return;


### PR DESCRIPTION
Some users forget the email they used to sign-up with Simperium. If (on a later moment) they have to sign-in, they accidentally sign-up for a new account with a different email username. Resulting in duplicate accounts for the users and all previous data will be removed (because of the Index Reconciliation). Off course this is fixed when they sign-in with the correct account, but most of the times they have to contact support to get this sorted out.

This PR saves the last used username and displays this username when the authentication view is shown. Also the current mechanism to display the sign-in/sign-up fields is replaced. This version shows the sign-in fields (if a previous username is available) even after app termination.

The Previous Username is enabled by default, but can be disabled using the following line:

`[SPAuthenticationConfiguration sharedInstance].previousUsernameEnabled = NO;`

Hope it helps!

Regards Patrick