### PR TITLE
Simperium: Committing pending CoreData OP's before quitting

### DIFF
--- a/Simperium/Simperium.m
+++ b/Simperium/Simperium.m
@@ -558,6 +558,12 @@ static SPLogLevels logLevel                     = SPLogLevelsInfo;
         dispatch_group_async(group, bucket.processorQueue, ^{ });
     }
     
+    // Make sure that any pending OP's get process'ed
+    dispatch_group_enter(group);
+    [self.coreDataStorage commitPendingOperations:^{
+        dispatch_group_leave(group);
+    }];
+    
     // When the queues are empty, the changes are expected to be saved locally
     dispatch_group_notify(group, dispatch_get_main_queue(), ^ {
         [[NSApplication sharedApplication] replyToApplicationShouldTerminate:YES];


### PR DESCRIPTION
#### Description:
This PR updates the OSX Helper *applicationShouldTerminate*, so that it makes sure that any pending CoreData OP gets processed, before the termination message is acknowledged.

#### Details:
This is a required patch to address a Simplenote issue, in which the users may loose new changes, if they close the app very quickly right afterwards.
