### PR TITLE
Trim username when validating.

### DIFF
--- a/Simperium-OSX/Simperium-OSX/SPAuthenticationWindowController.m
+++ b/Simperium-OSX/Simperium-OSX/SPAuthenticationWindowController.m
@@ -220,8 +220,9 @@ static CGFloat const SPAuthenticationProgressSize       = 20.0f;
     NSString *forgotPasswordURL = [[SPAuthenticationConfiguration sharedInstance] forgotPasswordURL];
     
     // Post the email already entered in the Username Field. This allows us to prefill the Forgot Password Form
-    if (self.usernameField.stringValue.length) {
-        NSString *parameters = [NSString stringWithFormat:@"?email=%@", self.usernameField.stringValue.sp_trim];
+    NSString *username = self.usernameField.stringValue.sp_trim;
+    if (username.length) {
+        NSString *parameters = [NSString stringWithFormat:@"?email=%@", username];
         forgotPasswordURL = [forgotPasswordURL stringByAppendingString:parameters];
     }
     

--- a/Simperium-OSX/Simperium-OSX/SPAuthenticationWindowController.m
+++ b/Simperium-OSX/Simperium-OSX/SPAuthenticationWindowController.m
@@ -221,7 +221,7 @@ static CGFloat const SPAuthenticationProgressSize       = 20.0f;
     
     // Post the email already entered in the Username Field. This allows us to prefill the Forgot Password Form
     if (self.usernameField.stringValue.length) {
-        NSString *parameters = [NSString stringWithFormat:@"?email=%@", self.usernameField.stringValue];
+        NSString *parameters = [NSString stringWithFormat:@"?email=%@", self.usernameField.stringValue.sp_trim];
         forgotPasswordURL = [forgotPasswordURL stringByAppendingString:parameters];
     }
     
@@ -276,7 +276,8 @@ static CGFloat const SPAuthenticationProgressSize       = 20.0f;
     [self.changeToSignUpButton setEnabled:NO];
     [self.usernameField setEnabled:NO];
     [self.passwordField setEnabled:NO];
-    [self.authenticator authenticateWithUsername:[self.usernameField stringValue] password:[self.passwordField stringValue]
+    [self.authenticator authenticateWithUsername:self.usernameField.stringValue.sp_trim
+                                        password:self.passwordField.stringValue
                                        success:^{
                                        }
                                        failure:^(int responseCode, NSString *responseString) {
@@ -305,7 +306,8 @@ static CGFloat const SPAuthenticationProgressSize       = 20.0f;
     [self.passwordField setEnabled:NO];
     [self.confirmField setEnabled:NO];
 
-    [self.authenticator createWithUsername:[self.usernameField stringValue] password:[self.passwordField stringValue]
+    [self.authenticator createWithUsername:self.usernameField.stringValue.sp_trim
+                                  password:self.passwordField.stringValue
                                  success:^{
                                      //[self close];
                                  }
@@ -330,7 +332,7 @@ static CGFloat const SPAuthenticationProgressSize       = 20.0f;
 # pragma mark Validation and Error Handling
 
 - (BOOL)validateUsername {
-    if (![self.validator validateUsername:self.usernameField.stringValue]) {
+    if (![self.validator validateUsername:self.usernameField.stringValue.sp_trim]) {
         [self earthquake:self.usernameField];
         [self showAuthenticationError:NSLocalizedString(@"Not a valid email address", @"Error when you enter a bad email address")];
         

--- a/Simperium/NSString+Simperium.h
+++ b/Simperium/NSString+Simperium.h
@@ -21,5 +21,6 @@
 
 - (NSString *)sp_urlEncodeString;
 - (NSArray *)sp_componentsSeparatedByString:(NSString *)separator limit:(NSInteger)limit;
+- (NSString *)sp_trim;
 
 @end

--- a/Simperium/NSString+Simperium.m
+++ b/Simperium/NSString+Simperium.m
@@ -149,4 +149,9 @@ static const char _base64EncodingTable[64] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefgh
     return components;
 }
 
+- (NSString *)sp_trim
+{
+    return [self stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+}
+
 @end

--- a/Simperium/SPAuthenticationViewController.m
+++ b/Simperium/SPAuthenticationViewController.m
@@ -17,7 +17,7 @@
 #import "SPWebViewController.h"
 
 #import "JSONKit+Simperium.h"
-
+#import "NSString+Simperium.h"
 
 #pragma mark ====================================================================================
 #pragma mark Private Properties
@@ -427,7 +427,7 @@ static NSString *SPAuthenticationConfirmCellIdentifier      = @"ConfirmCellIdent
 #pragma mark Validation
 
 - (BOOL)validateUsername {
-    if (![self.validator validateUsername:self.usernameField.text]) {
+    if (![self.validator validateUsername:[self.usernameField.text sp_trim]]) {
         NSString *errorText = NSLocalizedString(@"Your email address is not valid.", @"Message displayed when email address is invalid");
         [self.actionButton showErrorMessage:errorText];
         [self earthquake:[self.tableView cellForRowAtIndexPath:[self emailIndexPath]]];
@@ -478,7 +478,7 @@ static NSString *SPAuthenticationConfirmCellIdentifier      = @"ConfirmCellIdent
     
     [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
 
-    [self.authenticator authenticateWithUsername:self.usernameField.text
+    [self.authenticator authenticateWithUsername:[self.usernameField.text sp_trim]
                                         password:self.passwordField.text
                                          success:^{
                                             [self.progressView setHidden:YES];
@@ -536,7 +536,7 @@ static NSString *SPAuthenticationConfirmCellIdentifier      = @"ConfirmCellIdent
     // Try to login and sync after entering password?
     [self.progressView setHidden: NO];
     [self.progressView startAnimating];
-    [self.authenticator createWithUsername:self.usernameField.text
+    [self.authenticator createWithUsername:[self.usernameField.text sp_trim]
                                 password:self.passwordField.text
                                   success:^{
                                       [self.progressView setHidden: YES];
@@ -583,8 +583,9 @@ static NSString *SPAuthenticationConfirmCellIdentifier      = @"ConfirmCellIdent
     NSString *forgotPasswordURL = configuration.forgotPasswordURL;
     
     // Post the email already entered in the Username Field. This allows us to prefill the Forgot Password Form
-    if (self.usernameField.text.length) {
-        NSString *parameters = [NSString stringWithFormat:@"?email=%@", self.usernameField.text];
+    NSString *username = [self.usernameField.text sp_trim];
+    if (username.length) {
+        NSString *parameters = [NSString stringWithFormat:@"?email=%@", username];
         forgotPasswordURL = [forgotPasswordURL stringByAppendingString:parameters];
     }
     

--- a/SimperiumTests/NSStringSimperiumTest.m
+++ b/SimperiumTests/NSStringSimperiumTest.m
@@ -55,4 +55,13 @@
     }
 }
 
+- (void)testTrimingString
+{
+    NSString *sample = @"abc";
+    NSString *paddedSample = [NSString stringWithFormat:@"  %@  ", sample];
+
+    NSString *trimmedSample = [paddedSample sp_trim];
+    XCTAssertTrue([trimmedSample isEqualToString:sample], @"Extra white space should have been trimmed.");
+}
+
 @end


### PR DESCRIPTION
Fixes issue passing validation. Refs: https://github.com/Automattic/simplenote-ios/issues/327

To test: 
When authenticating, try entering a username with preceding and/or trailing spaces.  
Confirm the username passes validation. 

Needs Review: @jleandroperez 

PS. It wasn't clear to me how we're bumping the podspec version (just the tag or also the property in SPEnvironment?)  Let me know and I'll add that commit to this PR. 