### PR TITLE
Fixing DiffMatchPatch Crash

### DIFF
--- a/SimperiumTests/DiffMatchPatchTest.m
+++ b/SimperiumTests/DiffMatchPatchTest.m
@@ -1243,7 +1243,7 @@
   XCTAssertEqualObjects(@"x123\ttrue", resultStr, @"patch_apply: Edge partial match.");
 }
 
-- (void)testComposedCharacterStringsCrash {
+- (void)testComposedCharacterStringsSimperiumFix {
     NSString *oldString = @"あ ご a ご";
     NSString *newString = @"ご a ご";
     

--- a/SimperiumTests/DiffMatchPatchTest.m
+++ b/SimperiumTests/DiffMatchPatchTest.m
@@ -1243,6 +1243,15 @@
   XCTAssertEqualObjects(@"x123\ttrue", resultStr, @"patch_apply: Edge partial match.");
 }
 
+- (void)testComposedCharacterStringsCrash {
+    NSString *oldString = @"あ ご a ご";
+    NSString *newString = @"ご a ご";
+    
+    DiffMatchPatch *dmp = [DiffMatchPatch new];
+    XCTAssertNoThrow([dmp diff_computeFromOldString:oldString andNewString:newString checkLines:YES deadline:0]);
+}
+
+
 
 #pragma mark Test Utility Functions
 //  TEST UTILITY FUNCTIONS


### PR DESCRIPTION
There's a glitch in DiffMatchPatch's code that may trigger an Out of Bounds exception.
We've managed to isolate a sample of two strings that may trigger this behavior, and a unit test has been implemented:  `DiffMatchPatchTests`.`testComposedCharacterStringsSimperiumFix`.

Fix consists of simply relying on the `rangeOfString`'s `NSRange` length, instead of one of the receiver's length. From the Foundation.framework documentation:

```
/* These methods return length==0 if the target string is not found. So, to check for containment: ([str rangeOfString:@"target"].length > 0).  Note that the length of the range returned by these methods might be different than the length of the target string, due composed characters and such.
```

Closes #496
