### PR TITLE
TOS URL should use https

### DIFF
--- a/Simperium/SPEnvironment.m
+++ b/Simperium/SPEnvironment.m
@@ -18,7 +18,7 @@
 NSString* const SPBaseURL = @"https://api.simperium.com/1/";
 NSString* const SPAuthURL = @"https://auth.simperium.com/1/";
 NSString* const SPWebsocketURL = @"wss://api.simperium.com/sock/1";
-NSString* const SPTermsOfServiceURL = @"http://simperium.com/tos/";
+NSString* const SPTermsOfServiceURL = @"https://simperium.com/tos/";
 
 NSString* const SPAPIVersion = @"1.1";
 


### PR DESCRIPTION
As per iOS 9, Apple is now enforcing `https` usage by means of a plist setting: any http request will fail, unless the app is explicitly told to allow plain http requests.

As a safety measure, let's update the Terms of Service URL so that it uses *https*, and the request doesn't fail.
