### PR TITLE
AuthenticationViewController: Adaptivity Support

### DIFF
--- a/Simperium/SPAuthenticationViewController.m
+++ b/Simperium/SPAuthenticationViewController.m
@@ -411,14 +411,6 @@ static NSString *SPAuthenticationConfirmCellIdentifier      = @"ConfirmCellIdent
                      }];
 }
 
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
-    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
-        return YES;
-    }
-    
-    return (interfaceOrientation == UIInterfaceOrientationPortrait);
-}
-
 
 #pragma mark - Validation
 

--- a/Simperium/SPAuthenticationViewController.m
+++ b/Simperium/SPAuthenticationViewController.m
@@ -35,7 +35,7 @@ static CGFloat const SPAuthenticationFieldHeight            = 38.0f;
 
 static CGFloat const SPAuthenticationTableWidthMax          = 400.0f;
 static CGFloat const SPAuthenticationCompactPaddingY        = 20.0f;
-static CGFloat const SPAuthenticationRegularPaddingY        = 180.0f;
+static CGFloat const SPAuthenticationRegularPaddingY        = 160.0f;
 
 
 static CGFloat const SPAuthenticationLinkHeight             = 24.0f;
@@ -345,11 +345,7 @@ static NSString *SPAuthenticationConfirmCellIdentifier      = @"ConfirmCellIdent
     // Logo
     CGSize logoSize             = _logoView.frame.size;
     CGFloat contentHeight       = logoSize.height + _tableView.contentSize.height;
-    CGFloat topPadding          = SPAuthenticationRegularPaddingY;
-    
-    if ((contentHeight + 2 * topPadding) > targetSize.height) {
-        topPadding = SPAuthenticationCompactPaddingY;
-    }
+    CGFloat topPadding          = self.isRunningOnPad ? SPAuthenticationRegularPaddingY : SPAuthenticationCompactPaddingY;
     
     _logoView.frame             = CGRectIntegral(CGRectMake((targetSize.width - logoSize.width) * 0.5,
                                                             topPadding + self.topInset,

--- a/Simperium/SPAuthenticationViewController.m
+++ b/Simperium/SPAuthenticationViewController.m
@@ -351,7 +351,9 @@ static NSString *SPAuthenticationConfirmCellIdentifier      = @"ConfirmCellIdent
 }
 
 
-#pragma mark Keyboard
+
+
+#pragma mark - Keyboard
 
 - (void)keyboardWillShow:(NSNotification *)notification {
     
@@ -376,7 +378,6 @@ static NSString *SPAuthenticationConfirmCellIdentifier      = @"ConfirmCellIdent
 
 - (void)positionTableViewWithDuration:(CGFloat)duration {
     CGRect newFrame = self.view.bounds;
-    
     if (_keyboardHeight > 0) {
         CGFloat maxHeight = newFrame.size.height - _keyboardHeight - self.topInset;
         CGFloat tableViewHeight = [self.tableView tableFooterView].frame.origin.y + [self.tableView tableFooterView].frame.size.height;

--- a/Simperium/SPAuthenticationViewController.m
+++ b/Simperium/SPAuthenticationViewController.m
@@ -344,7 +344,6 @@ static NSString *SPAuthenticationConfirmCellIdentifier      = @"ConfirmCellIdent
 - (void)layoutViewsForTargetSize:(CGSize)targetSize {
     // Logo
     CGSize logoSize             = _logoView.frame.size;
-    CGFloat contentHeight       = logoSize.height + _tableView.contentSize.height;
     CGFloat topPadding          = self.isRunningOnPad ? SPAuthenticationRegularPaddingY : SPAuthenticationCompactPaddingY;
     
     _logoView.frame             = CGRectIntegral(CGRectMake((targetSize.width - logoSize.width) * 0.5,

--- a/Simperium/SPAuthenticationViewController.m
+++ b/Simperium/SPAuthenticationViewController.m
@@ -314,7 +314,7 @@ static NSString *SPAuthenticationConfirmCellIdentifier      = @"ConfirmCellIdent
 }
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
-    return (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) ? UIInterfaceOrientationMaskPortrait : UIInterfaceOrientationMaskAll;
+    return self.isRunningOnPad ? UIInterfaceOrientationMaskAll : UIInterfaceOrientationMaskPortrait;
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -358,7 +358,7 @@ static NSString *SPAuthenticationConfirmCellIdentifier      = @"ConfirmCellIdent
     
     // Table
     CGFloat tableViewOriginY    = CGRectGetMaxY(_logoView.frame);
-    CGFloat tableViewWidth      = MIN(targetSize.width, SPAuthenticationTableWidthMax);
+    CGFloat tableViewWidth      = self.isRunningOnPad ? SPAuthenticationTableWidthMax : targetSize.width;
     
     _tableView.frame            = CGRectIntegral(CGRectMake((targetSize.width - tableViewWidth) * 0.5,
                                                             tableViewOriginY,
@@ -366,6 +366,10 @@ static NSString *SPAuthenticationConfirmCellIdentifier      = @"ConfirmCellIdent
                                                             self.view.frame.size.height - tableViewOriginY));
     
     [self.view sendSubviewToBack:_logoView];
+}
+
+- (BOOL)isRunningOnPad {
+    return UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad;
 }
 
 

--- a/Simperium/SPAuthenticationViewController.m
+++ b/Simperium/SPAuthenticationViewController.m
@@ -420,7 +420,7 @@ static NSString *SPAuthenticationConfirmCellIdentifier      = @"ConfirmCellIdent
 }
 
 
-#pragma mark Validation
+#pragma mark - Validation
 
 - (BOOL)validateUsername {
     if (![self.validator validateUsername:[self.usernameField.text sp_trim]]) {
@@ -463,7 +463,7 @@ static NSString *SPAuthenticationConfirmCellIdentifier      = @"ConfirmCellIdent
 }
 
 
-#pragma mark Login
+#pragma mark - Login
 
 - (void)performLogin {
     self.view.userInteractionEnabled = NO;
@@ -509,7 +509,7 @@ static NSString *SPAuthenticationConfirmCellIdentifier      = @"ConfirmCellIdent
 }
 
 
-#pragma mark Creation
+#pragma mark - Creation
 
 - (void)restoreCreationSettings {
     self.actionButton.enabled = YES;
@@ -567,7 +567,7 @@ static NSString *SPAuthenticationConfirmCellIdentifier      = @"ConfirmCellIdent
 }
 
 
-#pragma mark Actions
+#pragma mark - Actions
 
 - (IBAction)termsAction:(id)sender {
     NSString *termsOfServiceURL = [[SPAuthenticationConfiguration sharedInstance] termsOfServiceURL];
@@ -627,7 +627,7 @@ static NSString *SPAuthenticationConfirmCellIdentifier      = @"ConfirmCellIdent
 }
 
 
-#pragma mark Text Field
+#pragma mark - Text Field
 
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
     [self.actionButton clearErrorMessage];
@@ -691,7 +691,7 @@ static NSString *SPAuthenticationConfirmCellIdentifier      = @"ConfirmCellIdent
 }
 
 
-#pragma mark Table Data Source Methods
+#pragma mark - Table Data Source Methods
 
 - (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section {
     return 4.0;
@@ -741,7 +741,7 @@ static NSString *SPAuthenticationConfirmCellIdentifier      = @"ConfirmCellIdent
 }
 
 
-#pragma mark Helpers
+#pragma mark - Helpers
 
 - (void)earthquake:(UIView*)itemView {
     // From http://stackoverflow.com/a/1827373/1379066

--- a/Simperium/SPAuthenticationViewController.m
+++ b/Simperium/SPAuthenticationViewController.m
@@ -152,6 +152,7 @@ static NSString *SPAuthenticationConfirmCellIdentifier      = @"ConfirmCellIdent
     _tableView.backgroundView = nil;
     _tableView.separatorColor = lightGreyColor;
     _tableView.clipsToBounds = NO;
+    _tableView.scrollEnabled = NO;
     [self.view addSubview:_tableView];
     
     if (self.view.bounds.size.height <= 480.0) {
@@ -328,14 +329,7 @@ static NSString *SPAuthenticationConfirmCellIdentifier      = @"ConfirmCellIdent
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     
-    self.tableView.scrollEnabled = NO;
-    
-    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
-        self.tableView.scrollEnabled = NO;
-        [self.tableView setBackgroundView:nil];
-    }
-
-    // register for keyboard notifications
+    // Register for keyboard notifications
     NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
     [nc addObserver:self selector:@selector(keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
     [nc addObserver:self selector:@selector(keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];

--- a/Simperium/SPAuthenticationViewController.m
+++ b/Simperium/SPAuthenticationViewController.m
@@ -354,7 +354,7 @@ static NSString *SPAuthenticationConfirmCellIdentifier      = @"ConfirmCellIdent
     
     // Table
     CGFloat tableViewOriginY    = CGRectGetMaxY(_logoView.frame);
-    CGFloat tableViewWidth      = self.isRunningOnPad ? SPAuthenticationTableWidthMax : targetSize.width;
+    CGFloat tableViewWidth      = self.isRunningOnPad ? MIN(SPAuthenticationTableWidthMax, targetSize.width) : targetSize.width;
     
     _tableView.frame            = CGRectIntegral(CGRectMake((targetSize.width - tableViewWidth) * 0.5,
                                                             tableViewOriginY,


### PR DESCRIPTION
In order to enable iOS 9 Multitasking Support, we need to add few fixes to `SPAuthenticationViewController`, so that it correctly reacts to screen resize events.

This has been tested on the following devices, in iOS 7 / 8 / 9:

- iPhone 4s
- iPhone 5s
- iPhone 6
- iPhone 6+
- iPad Air 2