### PR TITLE
Invisible Reauth Screen

### DIFF
--- a/Simperium.xcodeproj/project.pbxproj
+++ b/Simperium.xcodeproj/project.pbxproj
@@ -168,12 +168,14 @@
 		797D270119F1B72700DEF569 /* SPKeychainQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = 797D26FD19F1B72700DEF569 /* SPKeychainQuery.m */; };
 		B51397F11947612B004C1416 /* SPChangeProcessorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B51397F01947612B004C1416 /* SPChangeProcessorTests.m */; };
 		B52674721858EC4800A89D7A /* Simperium+Internals.h in Headers */ = {isa = PBXBuildFile; fileRef = B52674701858EC4800A89D7A /* Simperium+Internals.h */; };
-		B52DB6991BAC8F0A0039B6AE /* UIDevice+Simperium.h in Headers */ = {isa = PBXBuildFile; fileRef = B52DB6971BAC8F0A0039B6AE /* UIDevice+Simperium.h */; settings = {ASSET_TAGS = (); }; };
-		B52DB69A1BAC8F0A0039B6AE /* UIDevice+Simperium.m in Sources */ = {isa = PBXBuildFile; fileRef = B52DB6981BAC8F0A0039B6AE /* UIDevice+Simperium.m */; settings = {ASSET_TAGS = (); }; };
+		B52DB6991BAC8F0A0039B6AE /* UIDevice+Simperium.h in Headers */ = {isa = PBXBuildFile; fileRef = B52DB6971BAC8F0A0039B6AE /* UIDevice+Simperium.h */; };
+		B52DB69A1BAC8F0A0039B6AE /* UIDevice+Simperium.m in Sources */ = {isa = PBXBuildFile; fileRef = B52DB6981BAC8F0A0039B6AE /* UIDevice+Simperium.m */; };
 		B53F75A91A1BAB4600C0DDFB /* SPStorageObserverAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = B53F75A81A1BAB4600C0DDFB /* SPStorageObserverAdapter.m */; };
 		B5549FE318457F72007EA226 /* SPThreadsafeMutableSet.h in Headers */ = {isa = PBXBuildFile; fileRef = B5549FE118457F72007EA226 /* SPThreadsafeMutableSet.h */; };
 		B5549FE418457F72007EA226 /* SPThreadsafeMutableSet.m in Sources */ = {isa = PBXBuildFile; fileRef = B5549FE218457F72007EA226 /* SPThreadsafeMutableSet.m */; };
 		B5549FE6184581BF007EA226 /* SPThreadsafeMutableSetTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B5549FE5184581BF007EA226 /* SPThreadsafeMutableSetTests.m */; };
+		B55E98E21BDFFD5A0087CA48 /* UIViewController+Simperium.h in Headers */ = {isa = PBXBuildFile; fileRef = B55E98E01BDFFD5A0087CA48 /* UIViewController+Simperium.h */; };
+		B55E98E31BDFFD5A0087CA48 /* UIViewController+Simperium.m in Sources */ = {isa = PBXBuildFile; fileRef = B55E98E11BDFFD5A0087CA48 /* UIViewController+Simperium.m */; };
 		B56091551A717EE700A4E64A /* NSConditionLock+Simperium.h in Headers */ = {isa = PBXBuildFile; fileRef = B56091531A717EE700A4E64A /* NSConditionLock+Simperium.h */; };
 		B56091561A717EE700A4E64A /* NSConditionLock+Simperium.m in Sources */ = {isa = PBXBuildFile; fileRef = B56091541A717EE700A4E64A /* NSConditionLock+Simperium.m */; };
 		B565ECA2183261A600D162FF /* Test1.xcdatamodeld in Resources */ = {isa = PBXBuildFile; fileRef = 26ED4412146CF03A00C3D7D6 /* Test1.xcdatamodeld */; };
@@ -425,6 +427,8 @@
 		B5549FE118457F72007EA226 /* SPThreadsafeMutableSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = SPThreadsafeMutableSet.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		B5549FE218457F72007EA226 /* SPThreadsafeMutableSet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = SPThreadsafeMutableSet.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		B5549FE5184581BF007EA226 /* SPThreadsafeMutableSetTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = SPThreadsafeMutableSetTests.m; sourceTree = "<group>"; };
+		B55E98E01BDFFD5A0087CA48 /* UIViewController+Simperium.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Simperium.h"; sourceTree = "<group>"; };
+		B55E98E11BDFFD5A0087CA48 /* UIViewController+Simperium.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Simperium.m"; sourceTree = "<group>"; };
 		B56091531A717EE700A4E64A /* NSConditionLock+Simperium.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSConditionLock+Simperium.h"; sourceTree = "<group>"; };
 		B56091541A717EE700A4E64A /* NSConditionLock+Simperium.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSConditionLock+Simperium.m"; sourceTree = "<group>"; };
 		B565ECA71832940B00D162FF /* XCTestCase+Simperium.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCTestCase+Simperium.h"; sourceTree = "<group>"; };
@@ -815,6 +819,8 @@
 				B5C91A0D1827E9CB0002D306 /* NSURLResponse+Simperium.m */,
 				B52DB6971BAC8F0A0039B6AE /* UIDevice+Simperium.h */,
 				B52DB6981BAC8F0A0039B6AE /* UIDevice+Simperium.m */,
+				B55E98E01BDFFD5A0087CA48 /* UIViewController+Simperium.h */,
+				B55E98E11BDFFD5A0087CA48 /* UIViewController+Simperium.m */,
 			);
 			name = Categories;
 			sourceTree = "<group>";
@@ -1032,6 +1038,7 @@
 				2622FD10147F24CC00C8EEB4 /* SPMemberInt.h in Headers */,
 				B5DF229218B41E3200874C75 /* SPMemberJSON.h in Headers */,
 				B5C91A0A1827E8600002D306 /* SPHttpRequestQueue.h in Headers */,
+				B55E98E21BDFFD5A0087CA48 /* UIViewController+Simperium.h in Headers */,
 				B56091551A717EE700A4E64A /* NSConditionLock+Simperium.h in Headers */,
 				2622FD14147F24D700C8EEB4 /* SPMemberDouble.h in Headers */,
 				2622FD18147F24E000C8EEB4 /* SPMemberFloat.h in Headers */,
@@ -1316,6 +1323,7 @@
 				B5DF229318B41E3200874C75 /* SPMemberJSON.m in Sources */,
 				46DD15CB179A6F4B0093678C /* SPMemberJSONList.m in Sources */,
 				466EB41517BC45F5005F7599 /* SPAuthenticationConfiguration.m in Sources */,
+				B55E98E31BDFFD5A0087CA48 /* UIViewController+Simperium.m in Sources */,
 				466EB41717BC45F5005F7599 /* SPAuthenticationValidator.m in Sources */,
 				466EB41B17BC4890005F7599 /* SPAuthenticationButton.m in Sources */,
 				466FFEA417CBF53200399652 /* SPNetworkInterface.m in Sources */,

--- a/Simperium/Simperium.m
+++ b/Simperium/Simperium.m
@@ -811,7 +811,7 @@ static SPLogLevels logLevel                     = SPLogLevelsInfo;
     self.shouldSignIn = configuration.previousUsernameEnabled && configuration.previousUsernameLogged;
 
 #if TARGET_OS_IPHONE
-    if (self.authenticationViewController.sp_isViewOnscreen) {
+    if (self.authenticationViewController.sp_isViewAttached) {
         SPLogError(@"Error: Authentication Screen was already open");
         return;
     }
@@ -836,8 +836,8 @@ static SPLogLevels logLevel                     = SPLogLevelsInfo;
     }
     
     // Note:
-    // The RootViewController instance might be already presented another VC.
-    // Let's figure out which one is the leaf, and present form there.
+    // The RootViewController instance might be already presenting another VC.
+    // Let's figure out which one is the leaf, and present from there.
     //
     [self.rootViewController.sp_leafViewController presentViewController:controller animated:animated completion:nil];
 #else
@@ -858,7 +858,7 @@ static SPLogLevels logLevel                     = SPLogLevelsInfo;
 - (void)closeAuthViewControllerAnimated:(BOOL)animated {
 #if TARGET_OS_IPHONE
     // Login can either be its own root, or the first child of a nav controller if auth is optional
-    if (self.authenticationViewController.sp_isViewOnscreen) {
+    if (self.authenticationViewController.sp_isViewAttached) {
         [self.rootViewController dismissViewControllerAnimated:animated completion:nil];
     }
     self.authenticationViewController = nil;

--- a/Simperium/Simperium.m
+++ b/Simperium/Simperium.m
@@ -831,7 +831,7 @@ static SPLogLevels logLevel                     = SPLogLevelsInfo;
     self.authenticationViewController               = loginController;
     
     if (!self.rootViewController) {
-        UIWindow *window = [[[UIApplication sharedApplication] windows] firstObject];
+        UIWindow *window = [[UIApplication sharedApplication] keyWindow];
         self.rootViewController = [window rootViewController];
         NSAssert(self.rootViewController, @"Simperium error: to use built-in authentication, you must configure a rootViewController when you "
                                             "initialize Simperium, or call setParentViewControllerForAuthentication:. "

--- a/Simperium/Simperium.m
+++ b/Simperium/Simperium.m
@@ -835,7 +835,11 @@ static SPLogLevels logLevel                     = SPLogLevelsInfo;
         controller = [[UINavigationController alloc] initWithRootViewController:self.authenticationViewController];
     }
     
-    [self.rootViewController presentViewController:controller animated:animated completion:nil];
+    // Note:
+    // The RootViewController instance might be already presented another VC.
+    // Let's figure out which one is the leaf, and present form there.
+    //
+    [self.rootViewController.sp_leafViewController presentViewController:controller animated:animated completion:nil];
 #else
     if (!self.authenticationWindowController) {
         self.authenticationWindowController                 = [[self.authenticationWindowControllerClass alloc] init];

--- a/Simperium/Simperium.m
+++ b/Simperium/Simperium.m
@@ -831,10 +831,8 @@ static SPLogLevels logLevel                     = SPLogLevelsInfo;
     }
     
     UIViewController *controller = self.authenticationViewController;
-    UINavigationController *navController = nil;
     if (self.authenticationOptional) {
-        navController = [[UINavigationController alloc] initWithRootViewController: self.authenticationViewController];
-        controller = navController;
+        controller = [[UINavigationController alloc] initWithRootViewController:self.authenticationViewController];
     }
     
     [self.rootViewController presentViewController:controller animated:animated completion:nil];

--- a/Simperium/UIViewController+Simperium.h
+++ b/Simperium/UIViewController+Simperium.h
@@ -1,0 +1,17 @@
+//
+//  UIViewController.h
+//  Simperium
+//
+//  Created by Jorge Leandro Perez on 10/27/15.
+//  Copyright © 2015 Simperium. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+@interface UIViewController (Simperium)
+
+- (BOOL)sp_isViewOnscreen;
+- (UIViewController *)sp_leafViewController;
+
+@end

--- a/Simperium/UIViewController+Simperium.h
+++ b/Simperium/UIViewController+Simperium.h
@@ -11,7 +11,7 @@
 
 @interface UIViewController (Simperium)
 
-- (BOOL)sp_isViewOnscreen;
+- (BOOL)sp_isViewAttached;
 - (UIViewController *)sp_leafViewController;
 
 @end

--- a/Simperium/UIViewController+Simperium.m
+++ b/Simperium/UIViewController+Simperium.m
@@ -1,0 +1,32 @@
+//
+//  UIViewController.m
+//  Simperium
+//
+//  Created by Jorge Leandro Perez on 10/27/15.
+//  Copyright © 2015 Simperium. All rights reserved.
+//
+
+#import "UIViewController+Simperium.h"
+
+@implementation UIViewController (Simperium)
+
+- (BOOL)sp_isViewOnscreen
+{
+    BOOL visibleAsRoot          = self.view.window.rootViewController == self;
+    BOOL visibleAsTopOnStack    = self.navigationController.topViewController == self;
+    BOOL visibleAsPresented     = [self.view.window.rootViewController sp_leafViewController] == self;
+    
+    return visibleAsRoot || visibleAsTopOnStack || visibleAsPresented;
+}
+
+- (UIViewController *)sp_leafViewController
+{
+    UIViewController *leafViewController = self;
+    while (leafViewController.presentedViewController) {
+        leafViewController = leafViewController.presentedViewController;
+    }
+    
+    return leafViewController;
+}
+
+@end

--- a/Simperium/UIViewController+Simperium.m
+++ b/Simperium/UIViewController+Simperium.m
@@ -10,13 +10,9 @@
 
 @implementation UIViewController (Simperium)
 
-- (BOOL)sp_isViewOnscreen
+- (BOOL)sp_isViewAttached
 {
-    BOOL visibleAsRoot          = self.view.window.rootViewController == self;
-    BOOL visibleAsTopOnStack    = self.navigationController.topViewController == self;
-    BOOL visibleAsPresented     = [self.view.window.rootViewController sp_leafViewController] == self;
-    
-    return visibleAsRoot || visibleAsTopOnStack || visibleAsPresented;
+    return self.view.window != nil;
 }
 
 - (UIViewController *)sp_leafViewController


### PR DESCRIPTION
#### Description:
We're tracing a bug in Simplenote, in which the app would remain in an inconsistent state, in which the authentication token is no longer valid, still, the Auth Screen is not visible.

Suspected flow is **highly** unlikely, still, our only candidate to explain the weirdness we've been seeing.

#### Scenario
1. (_Unknown_) happens, and the Token gets corrupt
2. The websocket connection gets open, and the token is sent over
3. An auth response is received, in the form of `channel:auth:` (missing email).
4. **SPUser**'s email is nuked
5. The WebSocket connection gets severed, and reconnect kicks in
6. The Token is re-sent, and a proper `malformed / invalid token` response is received
7. AuthenticationViewController is presented

If this happens while there was *another* UIViewController instance being presented (such as Simplenote's Settings), the user may end up in a state in which the credentials are invalid (and thus, sync'ing is broken), still, there is no clear indication of what happened.

Needs Review: @aerych 
Eric, may i bother you with a quick peek? (Auth logic updated, so that the Login is presented from the Leaf ViewController).

Thank you!
