### PR TITLE
Prevents nuking the token on auth failure

### DIFF
--- a/Simperium/Simperium.m
+++ b/Simperium/Simperium.m
@@ -773,8 +773,11 @@ static SPLogLevels logLevel                     = SPLogLevelsInfo;
 }
 
 - (void)authenticationDidFail {
+    // Note:
+    // We're only nuking the authToken from memory (and not resetting the actual keychain), so that, in case of an (unknown)
+    // glitch (such as inaccessible token) we may just recover upon reauth // relaunch.
+    //
     [self stopNetworkManagers];
-    [self.authenticator reset];
     self.user.authToken = nil;
     
     [self failWithErrorCode:SPSimperiumErrorsInvalidToken];


### PR DESCRIPTION
On Authentication Failure, Simperium shouldn't nuke the token from the Keychain (nor the username from UserDefaults).

This way, if the app was affected by a keychain glitch, the app should just recover upon relaunch.

Needs Review: @fredrocious 
Thanks Fred!
