### PR TITLE
SPRWebSocket: Prevents Extension Collision

### DIFF
--- a/External/SocketRocket/SPRWebSocket.h
+++ b/External/SocketRocket/SPRWebSocket.h
@@ -107,7 +107,7 @@ extern NSString *const SPRHTTPResponseErrorKey;
 
 @end
 
-#pragma mark - NSURLRequest (CertificateAdditions)
+#pragma mark - NSURLRequest (SPRCertificateAdditions)
 
 @interface NSURLRequest (SPRCertificateAdditions)
 
@@ -115,9 +115,9 @@ extern NSString *const SPRHTTPResponseErrorKey;
 
 @end
 
-#pragma mark - NSMutableURLRequest (CertificateAdditions)
+#pragma mark - NSMutableURLRequest (SPRCertificateAdditions)
 
-@interface NSMutableURLRequest (CertificateAdditions)
+@interface NSMutableURLRequest (SPRCertificateAdditions)
 
 @property (nonatomic, retain) NSArray *SPR_SSLPinnedCertificates;
 

--- a/External/SocketRocket/SPRWebSocket.m
+++ b/External/SocketRocket/SPRWebSocket.m
@@ -1620,7 +1620,7 @@ static const size_t SRFrameHeaderOverhead = 32;
 @end
 
 
-@implementation  NSURLRequest (CertificateAdditions)
+@implementation  NSURLRequest (SPRCertificateAdditions)
 
 - (NSArray *)SPR_SSLPinnedCertificates;
 {
@@ -1629,7 +1629,7 @@ static const size_t SRFrameHeaderOverhead = 32;
 
 @end
 
-@implementation  NSMutableURLRequest (CertificateAdditions)
+@implementation  NSMutableURLRequest (SPRCertificateAdditions)
 
 - (NSArray *)SPR_SSLPinnedCertificates;
 {


### PR DESCRIPTION
#### Details:
Projects that *also* use SocketRocket are exhibiting a warning, due to the duplicate category `CertificateAdditions` in **NSURLRequest** extensions.

This causes no side effect: just a compiler warning.
