### PR TITLE
Preventing NSDictionary Nil Insertion

### DIFF
--- a/Simperium/SPMemberDouble.m
+++ b/Simperium/SPMemberDouble.m
@@ -65,6 +65,7 @@ static SPLogLevels logLevel = SPLogLevelsInfo;
 
 - (NSDictionary *)transform:(id)thisValue otherValue:(id)otherValue oldValue:(id)oldValue error:(NSError **)error {
     // By default, don't transform anything, and take the local pending value
+    thisValue = thisValue ?: [self defaultValue];
     return @{
         OP_OP       : OP_REPLACE,
         OP_VALUE    : thisValue

--- a/Simperium/SPMemberDouble.m
+++ b/Simperium/SPMemberDouble.m
@@ -65,11 +65,7 @@ static SPLogLevels logLevel = SPLogLevelsInfo;
 
 - (NSDictionary *)transform:(id)thisValue otherValue:(id)otherValue oldValue:(id)oldValue error:(NSError **)error {
     // By default, don't transform anything, and take the local pending value
-    thisValue = thisValue ?: [self defaultValue];
-    return @{
-        OP_OP       : OP_REPLACE,
-        OP_VALUE    : thisValue
-    };
+    return [NSDictionary dictionaryWithObjectsAndKeys:OP_REPLACE, OP_OP, thisValue, OP_VALUE, nil];
 }
 
 @end

--- a/Simperium/SPMemberDouble.m
+++ b/Simperium/SPMemberDouble.m
@@ -55,8 +55,8 @@ static SPLogLevels logLevel = SPLogLevelsInfo;
 }
 
 - (id)applyDiff:(id)thisValue otherValue:(id)otherValue error:(NSError **)error {
-    NSAssert([thisValue isKindOfClass:[NSNumber class]] && [otherValue isKindOfClass:[NSNumber class]],
-            @"Simperium error: couldn't apply diff to ints because their classes weren't NSNumber");
+    NSAssert(thisValue == nil || [thisValue isKindOfClass:[NSNumber class]], @"Simperium error: couldn't apply diff to double because its class wasn't NSNumber");
+    NSAssert(otherValue == nil || [otherValue isKindOfClass:[NSNumber class]], @"Simperium error: couldn't apply diff to double because its class wasn't NSNumber");
     
     // Integer changes just replace the previous value by default
     // TODO: Not sure if this should be a copy or not...

--- a/Simperium/SPMemberInt.m
+++ b/Simperium/SPMemberInt.m
@@ -62,8 +62,8 @@ static SPLogLevels logLevel = SPLogLevelsInfo;
 }
 
 - (id)applyDiff:(id)thisValue otherValue:(id)otherValue error:(NSError **)error {
-    NSAssert([thisValue isKindOfClass:[NSNumber class]] && [otherValue isKindOfClass:[NSNumber class]],
-            @"Simperium error: couldn't apply diff to ints because their classes weren't NSNumber");
+    NSAssert(thisValue == nil || [thisValue isKindOfClass:[NSNumber class]], @"Simperium error: couldn't apply diff to double because its class wasn't NSNumber");
+    NSAssert(otherValue == nil || [otherValue isKindOfClass:[NSNumber class]], @"Simperium error: couldn't apply diff to double because its class wasn't NSNumber");
     
     // Integer changes just replace the previous value by default
     // TODO: Not sure if this should be a copy or not...

--- a/Simperium/SPMemberInt.m
+++ b/Simperium/SPMemberInt.m
@@ -72,6 +72,7 @@ static SPLogLevels logLevel = SPLogLevelsInfo;
 
 - (NSDictionary *)transform:(id)thisValue otherValue:(id)otherValue oldValue:(id)oldValue error:(NSError **)error {
     // By default, don't transform anything, and take the local pending value
+    thisValue = thisValue ?: [self defaultValue];
     return @{
         OP_OP       : OP_REPLACE,
         OP_VALUE    : thisValue

--- a/Simperium/SPMemberInt.m
+++ b/Simperium/SPMemberInt.m
@@ -72,11 +72,7 @@ static SPLogLevels logLevel = SPLogLevelsInfo;
 
 - (NSDictionary *)transform:(id)thisValue otherValue:(id)otherValue oldValue:(id)oldValue error:(NSError **)error {
     // By default, don't transform anything, and take the local pending value
-    thisValue = thisValue ?: [self defaultValue];
-    return @{
-        OP_OP       : OP_REPLACE,
-        OP_VALUE    : thisValue
-    };
+    return [NSDictionary dictionaryWithObjectsAndKeys:OP_REPLACE, OP_OP, thisValue, OP_VALUE, nil];
 }
 
 @end


### PR DESCRIPTION
#### Details:
In this PR we're handling a scenario in which nil values might get inserted into a `NSDictionaryPlaceholder`, and thus crashing the host app.

@larryryu would it be possible to validate the fix?
Thanks in advance!

Fixes #533 