### PR TITLE
Fix for Discarded Remote Changes (when defaults values are set in core data model)

### DIFF
--- a/Simperium/SPChangeProcessor.m
+++ b/Simperium/SPChangeProcessor.m
@@ -313,7 +313,7 @@ static int const SPChangeProcessorMaxPendingChanges = 200;
             if (oldDiff.count) {
                 // The local client version changed in the meantime, so transform the diff before applying it
                 SPLogVerbose(@"Simperium applying transform to diff: %@", diff);
-                diff = [bucket.differ transform:object diff:oldDiff oldDiff:diff oldGhost:oldGhost error:&theError];
+                NSDictionary *localDiff = [bucket.differ transform:object diff:oldDiff oldDiff:diff oldGhost:oldGhost error:&theError];
                 if (theError) {
                     SPLogError(@"Simperium error during diff transform: %@", theError.localizedDescription);
                     if (error) {
@@ -325,7 +325,7 @@ static int const SPChangeProcessorMaxPendingChanges = 200;
                 // Load from the ghost data so the subsequent diff is applied to the correct data
                 // Do an extra check in case there was a problem with the transform/diff, e.g. if a client's own change was misinterpreted
                 // as another client's change, in other words not properly acknowledged.
-                if (diff.count) {
+                if (localDiff.count) {
                     [object loadMemberData:object.ghost.memberData];
                     [self enqueueObjectForMoreChanges:simperiumKey bucket:bucket];
                 } else {

--- a/Simperium/SPDiffer.h
+++ b/Simperium/SPDiffer.h
@@ -29,5 +29,5 @@
 - (BOOL)applyDiffFromDictionary:(NSDictionary *)diff toObject:(id<SPDiffable>)object error:(NSError **)error;
 - (BOOL)applyGhostDiffFromDictionary:(NSDictionary *)diff toObject:(id<SPDiffable>)object error:(NSError **)error;
 - (NSDictionary *)transform:(id<SPDiffable>)object diff:(NSDictionary *)diff oldDiff:(NSDictionary *)oldDiff oldGhost:(SPGhost *)oldGhost error:(NSError **)error;
-
+- (NSDictionary *)diffByMergingDiff:(NSDictionary *)diff2 intoDiff:(NSDictionary *)diff1 overwrite:(BOOL)overwrite;
 @end

--- a/Simperium/SPDiffer.m
+++ b/Simperium/SPDiffer.m
@@ -288,4 +288,16 @@ static SPLogLevels logLevel = SPLogLevelsInfo;
     return newDiff;
 }
 
+- (NSDictionary *)diffByMergingDiff:(NSDictionary *)diff2 intoDiff:(NSDictionary *)diff1 overwrite:(BOOL)overwrite{
+    //if overwite == NO, then only add value from diff2 if it doesn't exist in diff1
+    NSMutableDictionary *combinedDiff = [diff1 mutableCopy] ?: [[NSMutableDictionary alloc] init];
+    for (NSString *key in diff2) {
+        if (overwrite || (!overwrite && !diff1[key])) {
+            combinedDiff[key] = diff2[key];
+        }
+    }
+    
+    return [combinedDiff copy];
+}
+
 @end

--- a/Simperium/SPDiffer.m
+++ b/Simperium/SPDiffer.m
@@ -248,7 +248,6 @@ static SPLogLevels logLevel = SPLogLevelsInfo;
         
         if (!ghostValue) {
             SPLogError(@"Simperium error: transform diff for a ghost member (ghost %@, memberData %@) that doesn't exist (%@): %@", oldGhost, oldGhost.memberData, key, [change description]);
-            continue;
         }
         
         // Could handle some weird cases here related to dynamically adding/removing members; ignore for now


### PR DESCRIPTION
No longer overwriting diff generated from remote change with diff between a ManagedObject and it's ghostData

More details here: https://github.com/Simperium/simperium-ios/issues/547
