### PR TITLE
The fixes a bug where nil date gets converted to 0 which is 01/01/1970

### DIFF
--- a/Simperium/SPMemberDate.m
+++ b/Simperium/SPMemberDate.m
@@ -29,6 +29,10 @@ static SPLogLevels logLevel = SPLogLevelsInfo;
 }
 
 - (id)dateValueFromNumber:(id)value {
+    if (!value || [value isEqual:[NSNull null]]){
+        return nil;
+    }
+    
     if ([value isKindOfClass:[NSNumber class]])
         return value;
     
@@ -39,7 +43,7 @@ static SPLogLevels logLevel = SPLogLevelsInfo;
 
 - (id)getValueFromDictionary:(NSDictionary *)dict key:(NSString *)key object:(id<SPDiffable>)object {
     id value = [dict objectForKey:key];
-    if (!value) {
+    if (!value || [value isEqual:[NSNull null]]) {
         return nil;
     }
     


### PR DESCRIPTION
Ran into an issue where date fields with nil values would eventually generate a diff for a change from 0 to nil. Even though nothing hand changed. Traced it down to this method

`````
 - (id)dateValueFromNumber:(id)value
````
 returning 0 if the number is nil

This occurrs a lot when simperium fetches all data upon login