### PR TITLE
Adds account creation notification to Authenticator / Simperium delegates

### DIFF
--- a/Simperium/Info.plist
+++ b/Simperium/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.15</string>
+	<string>0.8.16</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Simperium/SPAuthenticator.h
+++ b/Simperium/SPAuthenticator.h
@@ -22,6 +22,7 @@ typedef void(^FailedBlockType)(int responseCode, NSString *responseString);
 @protocol SPAuthenticatorDelegate <NSObject>
 @optional
 - (void)authenticationDidSucceedForUsername:(NSString *)username token:(NSString *)token;
+- (void)authenticationDidCreateAccount;
 - (void)authenticationDidFail;
 - (void)authenticationDidCancel;
 @end

--- a/Simperium/SPAuthenticator.m
+++ b/Simperium/SPAuthenticator.m
@@ -200,6 +200,15 @@ static NSString * SPUsername    = @"SPUsername";
     [self performSelector:@selector(delayedAuthenticationDidFinish) withObject:nil afterDelay:0.1];
 }
 
+- (void)authWithCreationDidSucceed:(SPHttpRequest *)request
+{
+    [self authDidSucceed:request];
+
+    if ([self.delegate respondsToSelector:@selector(authenticationDidCreateAccount)]) {
+        [self.delegate authenticationDidCreateAccount];
+    }
+}
+
 - (void)authDidFail:(SPHttpRequest *)request {
     if (self.failedBlock) {
         self.failedBlock(request.responseCode, request.responseString);
@@ -250,7 +259,7 @@ static NSString * SPUsername    = @"SPUsername";
     
     // Selectors are for auth-related handling
     request.delegate = self;
-    request.selectorSuccess = @selector(authDidSucceed:);
+    request.selectorSuccess = @selector(authWithCreationDidSucceed:);
     request.selectorFailed = @selector(authDidFail:);
 
     [[SPHttpRequestQueue sharedInstance] enqueueHttpRequest:request];

--- a/Simperium/SPEnvironment.m
+++ b/Simperium/SPEnvironment.m
@@ -30,7 +30,7 @@ NSString* const SPLibraryID = @"osx";
 #endif
 
 // TODO: Update this automatically via a script that looks at current git tag
-NSString* const SPLibraryVersion = @"0.8.15";
+NSString* const SPLibraryVersion = @"0.8.16";
 
 // SSL Certificate Expiration: '2016-09-07 02:36:04 +0000' expressed as seconds since 1970
 NSTimeInterval const SPCertificateExpiration = 1473215764;

--- a/Simperium/Simperium.h
+++ b/Simperium/Simperium.h
@@ -58,6 +58,7 @@ typedef NS_ENUM(NSInteger, SPSimperiumErrors) {
 - (void)simperiumDidLogin:(Simperium *)simperium;
 - (void)simperiumDidLogout:(Simperium *)simperium;
 - (void)simperiumDidCancelLogin:(Simperium *)simperium;
+- (void)simperiumDidCreateAccount:(Simperium *)simperium;
 @end
 
 

--- a/Simperium/Simperium.m
+++ b/Simperium/Simperium.m
@@ -765,6 +765,13 @@ static SPLogLevels logLevel                     = SPLogLevelsInfo;
     }
 }
 
+- (void)authenticationDidCreateAccount
+{
+    if ([self.delegate respondsToSelector:@selector(simperiumDidCreateAccount:)]) {
+        [self.delegate simperiumDidCreateAccount:self];
+    }
+}
+
 - (void)authenticationDidCancel {
     [self stopNetworkManagers];
     [self.authenticator reset];


### PR DESCRIPTION
Delegates of `Simperium` can now be informed when a new account was created. Previously this wasn't possible.

I've also bumped the pod / library version, as I need to use this elsewhere.

Needs review: @jleandroperez 