### PR TITLE
SPWebSocketChannel: Setting lastChangeSignature on empty buckets

### DIFF
--- a/Simperium/SPWebSocketChannel.m
+++ b/Simperium/SPWebSocketChannel.m
@@ -429,7 +429,7 @@ typedef void(^SPWebSocketSyncedBlockType)(void);
     if ([current isKindOfClass:[NSNumber class]]) {
         current = [NSString stringWithFormat:@"%ld", (long)[current integerValue]];
     }
-    self.pendingLastChangeSignature = [current length] > 0 ? [NSString stringWithFormat:@"%@", current] : nil;
+    self.pendingLastChangeSignature = [current length] > 0 ? [NSString stringWithFormat:@"%@", current] : @"";
     self.nextMark                   = responseDict[@"mark"];
     
     // Remember all the retrieved data in case there's more to get


### PR DESCRIPTION
### Details:
In this PR we're setting an empty string, as the lastChangeSignature, whenever the indexed bucket is actually empty.

This will prevent constant reindex on empty buckets.

### Testing:
1. Open the **SimpletodoFinal** app (`samples` folder)
2. Replace the `SIMPERIUM_APP_ID` and `SIMPERIUM_API_KEY` keys with a fresh app
3. Add, [in this spot](https://github.com/Simperium/simperium-ios/blob/develop/samples/Simpletodo/SimpletodoFinal/SPAppDelegate.m#L46), the following snippet:
```
    self.simperium.verboseLoggingEnabled = true;
```
4. Launch the demo app and signup
5. Restart the app

Verify that after relaunching, the console won't show a reindex cycle anymore.

Needs review: @roundhill 
Thanks in advance sir!

