### PR TITLE
Fix retain cycle in SPRWebSocket

### DIFF
--- a/External/SocketRocket/SPRWebSocket.m
+++ b/External/SocketRocket/SPRWebSocket.m
@@ -465,10 +465,10 @@ static __strong NSData *CRLFCRLF;
     }
                         
     [self _readUntilHeaderCompleteWithCallback:^(SPRWebSocket *self,  NSData *data) {
-        CFHTTPMessageAppendBytes(_receivedHTTPHeaders, (const UInt8 *)data.bytes, data.length);
+        CFHTTPMessageAppendBytes(self->_receivedHTTPHeaders, (const UInt8 *)data.bytes, data.length);
         
-        if (CFHTTPMessageIsHeaderComplete(_receivedHTTPHeaders)) {
-            SRFastLog(@"Finished reading headers %@", CFBridgingRelease(CFHTTPMessageCopyAllHeaderFields(_receivedHTTPHeaders)));
+        if (CFHTTPMessageIsHeaderComplete(self->_receivedHTTPHeaders)) {
+            SRFastLog(@"Finished reading headers %@", CFBridgingRelease(CFHTTPMessageCopyAllHeaderFields(self->_receivedHTTPHeaders)));
             [self _HTTPHeadersDidFinish];
         } else {
             [self _readHTTPHeader];


### PR DESCRIPTION
This breaks a retain cycle in SPRWebSocket caused by an implicitly captured reference to self for access of the _receivedHTTPHeaders instance variable. The implicit reference is replaced by an explicit reference through the self callback argument, as used for instance variable access in the other callback blocks.

The scenario in which I encountered this is unusual, but is responsible for a significant memory leak in Simplenote for macOS. A company I work for has a proxy deployed on their network that performs HTTPS intercept. Users are expected to trust the proxy's certificate on their devices and allow their secure traffic to be decrypted and monitored. I decline to do this on my personal machine, so when I VPN into this network Simplenote fails to connect due to the untrusted certificate. It then retries every 2 seconds, creating a new SPRWebSocket instance each time that is leaked due to this cycle. This results in a leak of about 1mb per minute.