### PR TITLE
Allow Authentication controller subclasses to control UI state

### DIFF
--- a/Simperium-OSX/SPAuthenticationWindowController.h
+++ b/Simperium-OSX/SPAuthenticationWindowController.h
@@ -23,4 +23,6 @@
 - (IBAction)signUpAction:(id)sender;
 - (IBAction)signInAction:(id)sender;
 
+- (void)setSigningIn:(BOOL)signingIn;
+
 @end


### PR DESCRIPTION
I'd like to default Simplenote macOS/iOS to show the `sign in` view by default, currently it defaults to the `sign up` view.

Expose the `setSigningIn` method so login controller subclasses can control the default state of the login form.