### PR TITLE
Bugfix: DiffMatchPatch Surrogate Pairs Support

### DIFF
--- a/External/diffmatchpatch/DiffMatchPatchCFUtilities.c
+++ b/External/diffmatchpatch/DiffMatchPatchCFUtilities.c
@@ -692,7 +692,7 @@ CFIndex diff_cleanupSemanticScore(CFStringRef one, CFStringRef two) {
   } else if (whitespace1 || whitespace2) {
     // Two points for whitespace.
     return 2;
-  } else if (nonAlphaNumeric1 && !char1IsSurrogate || nonAlphaNumeric2 && !char1IsSurrogate) {
+  } else if ((nonAlphaNumeric1 && !char1IsSurrogate) || (nonAlphaNumeric2 && !char2IsSurrogate)) {
     // One point for non-alphanumeric.
     return 1;
   }

--- a/External/diffmatchpatch/DiffMatchPatchCFUtilities.c
+++ b/External/diffmatchpatch/DiffMatchPatchCFUtilities.c
@@ -655,27 +655,19 @@ CFIndex diff_cleanupSemanticScore(CFStringRef one, CFStringRef two) {
   // 'whitespace'.  Since this function's purpose is largely cosmetic,
   // the choice has been made to use each language's native features
   // rather than force total conformity.
-  UniChar char1 =
-  CFStringGetCharacterAtIndex(one, (CFStringGetLength(one) - 1));
-  UniChar char2 =
-  CFStringGetCharacterAtIndex(two, 0);
-  Boolean nonAlphaNumeric1 =
-  !CFCharacterSetIsCharacterMember(alphaNumericSet, char1);
-  Boolean nonAlphaNumeric2 =
-  !CFCharacterSetIsCharacterMember(alphaNumericSet, char2);
-  Boolean whitespace1 =
-  nonAlphaNumeric1 && CFCharacterSetIsCharacterMember(whiteSpaceSet, char1);
-  Boolean whitespace2 =
-  nonAlphaNumeric2 && CFCharacterSetIsCharacterMember(whiteSpaceSet, char2);
-  Boolean lineBreak1 =
-  whitespace1 && CFCharacterSetIsCharacterMember(controlSet, char1);
-  Boolean lineBreak2 =
-  whitespace2 && CFCharacterSetIsCharacterMember(controlSet, char2);
-  Boolean blankLine1 =
-  lineBreak1 && diff_regExMatch(one, &blankLineEndRegEx);
-  Boolean blankLine2 =
-  lineBreak2 && diff_regExMatch(two, &blankLineStartRegEx);
-  
+  UniChar char1 = CFStringGetCharacterAtIndex(one, (CFStringGetLength(one) - 1));
+  UniChar char2 = CFStringGetCharacterAtIndex(two, 0);
+  Boolean char1IsSurrogate = CFStringIsSurrogateLowCharacter(char1) || CFStringIsSurrogateHighCharacter(char1);
+  Boolean char2IsSurrogate = CFStringIsSurrogateLowCharacter(char2) || CFStringIsSurrogateHighCharacter(char1);
+  Boolean nonAlphaNumeric1 = !CFCharacterSetIsCharacterMember(alphaNumericSet, char1);
+  Boolean nonAlphaNumeric2 = !CFCharacterSetIsCharacterMember(alphaNumericSet, char2);
+  Boolean whitespace1 = nonAlphaNumeric1 && CFCharacterSetIsCharacterMember(whiteSpaceSet, char1);
+  Boolean whitespace2 = nonAlphaNumeric2 && CFCharacterSetIsCharacterMember(whiteSpaceSet, char2);
+  Boolean lineBreak1 = whitespace1 && CFCharacterSetIsCharacterMember(controlSet, char1);
+  Boolean lineBreak2 = whitespace2 && CFCharacterSetIsCharacterMember(controlSet, char2);
+  Boolean blankLine1 = lineBreak1 && diff_regExMatch(one, &blankLineEndRegEx);
+  Boolean blankLine2 = lineBreak2 && diff_regExMatch(two, &blankLineStartRegEx);
+
   if (blankLine1 || blankLine2) {
     // Five points for blank lines.
     return 5;
@@ -688,7 +680,7 @@ CFIndex diff_cleanupSemanticScore(CFStringRef one, CFStringRef two) {
   } else if (whitespace1 || whitespace2) {
     // Two points for whitespace.
     return 2;
-  } else if (nonAlphaNumeric1 || nonAlphaNumeric2) {
+  } else if (nonAlphaNumeric1 && !char1IsSurrogate || nonAlphaNumeric2 && !char1IsSurrogate) {
     // One point for non-alphanumeric.
     return 1;
   }

--- a/External/diffmatchpatch/DiffMatchPatchCFUtilities.c
+++ b/External/diffmatchpatch/DiffMatchPatchCFUtilities.c
@@ -112,6 +112,9 @@ CFIndex diff_commonPrefix(CFStringRef text1, CFStringRef text2) {
     char2 = CFStringGetCharacterFromInlineBuffer(&text2_inlineBuffer, i);
 
     if (char1 != char2) {
+        if ( CFStringIsSurrogateLowCharacter(char1) || CFStringIsSurrogateHighCharacter(char1) ) {
+            i = MAX(i - 1, 0);
+        }
       return i;
     }
   }
@@ -142,7 +145,11 @@ CFIndex diff_commonSuffix(CFStringRef text1, CFStringRef text2) {
     char2 = CFStringGetCharacterFromInlineBuffer(&text2_inlineBuffer, (text2_length - i));
 
     if (char1 != char2) {
-      return i - 1;
+        if ( CFStringIsSurrogateLowCharacter(char1) || CFStringIsSurrogateHighCharacter(char1) ) {
+            return MIN(i - 2, 0);
+        }
+
+        return i - 1;
     }
   }
   return n;

--- a/External/diffmatchpatch/DiffMatchPatchCFUtilities.c
+++ b/External/diffmatchpatch/DiffMatchPatchCFUtilities.c
@@ -655,18 +655,30 @@ CFIndex diff_cleanupSemanticScore(CFStringRef one, CFStringRef two) {
   // 'whitespace'.  Since this function's purpose is largely cosmetic,
   // the choice has been made to use each language's native features
   // rather than force total conformity.
-  UniChar char1 = CFStringGetCharacterAtIndex(one, (CFStringGetLength(one) - 1));
-  UniChar char2 = CFStringGetCharacterAtIndex(two, 0);
-  Boolean char1IsSurrogate = CFStringIsSurrogateLowCharacter(char1) || CFStringIsSurrogateHighCharacter(char1);
-  Boolean char2IsSurrogate = CFStringIsSurrogateLowCharacter(char2) || CFStringIsSurrogateHighCharacter(char1);
-  Boolean nonAlphaNumeric1 = !CFCharacterSetIsCharacterMember(alphaNumericSet, char1);
-  Boolean nonAlphaNumeric2 = !CFCharacterSetIsCharacterMember(alphaNumericSet, char2);
-  Boolean whitespace1 = nonAlphaNumeric1 && CFCharacterSetIsCharacterMember(whiteSpaceSet, char1);
-  Boolean whitespace2 = nonAlphaNumeric2 && CFCharacterSetIsCharacterMember(whiteSpaceSet, char2);
-  Boolean lineBreak1 = whitespace1 && CFCharacterSetIsCharacterMember(controlSet, char1);
-  Boolean lineBreak2 = whitespace2 && CFCharacterSetIsCharacterMember(controlSet, char2);
-  Boolean blankLine1 = lineBreak1 && diff_regExMatch(one, &blankLineEndRegEx);
-  Boolean blankLine2 = lineBreak2 && diff_regExMatch(two, &blankLineStartRegEx);
+  UniChar char1 =
+  CFStringGetCharacterAtIndex(one, (CFStringGetLength(one) - 1));
+  UniChar char2 =
+  CFStringGetCharacterAtIndex(two, 0);
+  Boolean char1IsSurrogate =
+  CFStringIsSurrogateLowCharacter(char1) || CFStringIsSurrogateHighCharacter(char1);
+  Boolean char2IsSurrogate =
+  CFStringIsSurrogateLowCharacter(char2) || CFStringIsSurrogateHighCharacter(char1);
+  Boolean nonAlphaNumeric1 =
+  !CFCharacterSetIsCharacterMember(alphaNumericSet, char1);
+  Boolean nonAlphaNumeric2 =
+  !CFCharacterSetIsCharacterMember(alphaNumericSet, char2);
+  Boolean whitespace1 =
+  nonAlphaNumeric1 && CFCharacterSetIsCharacterMember(whiteSpaceSet, char1);
+  Boolean whitespace2 =
+  nonAlphaNumeric2 && CFCharacterSetIsCharacterMember(whiteSpaceSet, char2);
+  Boolean lineBreak1 =
+  whitespace1 && CFCharacterSetIsCharacterMember(controlSet, char1);
+  Boolean lineBreak2 =
+  whitespace2 && CFCharacterSetIsCharacterMember(controlSet, char2);
+  Boolean blankLine1 =
+  lineBreak1 && diff_regExMatch(one, &blankLineEndRegEx);
+  Boolean blankLine2 =
+  lineBreak2 && diff_regExMatch(two, &blankLineStartRegEx);
 
   if (blankLine1 || blankLine2) {
     // Five points for blank lines.

--- a/SimperiumTests/DiffMatchPatchTest.m
+++ b/SimperiumTests/DiffMatchPatchTest.m
@@ -412,6 +412,21 @@
   XCTAssertEqualObjects(expectedResult, diffs, @"Sentence boundaries.");
 }
 
+- (void)testDiffCleanupSemanticLosslessDoesNotTamperWithSurrogatePairsTest {
+    NSArray *expected = @[
+        [Diff diffWithOperation:DIFF_EQUAL andText:@"☺️"],
+        [Diff diffWithOperation:DIFF_INSERT andText:@"😃"],
+        [Diff diffWithOperation:DIFF_EQUAL andText:@"🖖🏿"]
+    ];
+
+    NSMutableArray *diffs = [expected mutableCopy];
+
+    DiffMatchPatch *dmp = [DiffMatchPatch new];
+    [dmp diff_cleanupSemanticLossless:diffs];
+
+    XCTAssertEqualObjects(diffs, expected, @"The result should match the input!");
+}
+
 - (void)testDiffCleanupSemanticTest {
   DiffMatchPatch *dmp = [DiffMatchPatch new];
   NSMutableArray *expectedResult = nil;

--- a/SimperiumTests/DiffMatchPatchTest.m
+++ b/SimperiumTests/DiffMatchPatchTest.m
@@ -48,6 +48,17 @@
   XCTAssertEqual((NSUInteger)4, [dmp diff_commonPrefixOfFirstString:@"1234" andSecondString:@"1234xyz"], @"Common suffix whole case failed.");
 }
 
+- (void)testDiffCommonPrefixDoesntSplitSurrogatePairs {
+  DiffMatchPatch *dmp = [DiffMatchPatch new];
+
+  NSString *pristine = @"☺️🖖🏿";
+  NSString *edited = @"☺️😃🖖🏿";
+  NSString *common = @"☺️";
+
+  NSUInteger prefix = [dmp diff_commonPrefixOfFirstString:pristine andSecondString:edited];
+  XCTAssertEqual(prefix, common.length, @"Common Prefix should match the common emoji's length");
+}
+
 - (void)testDiffCommonSuffixTest {
   DiffMatchPatch *dmp = [DiffMatchPatch new];
 
@@ -60,6 +71,19 @@
 
   // Whole case.
   XCTAssertEqual((NSUInteger)4, [dmp diff_commonSuffixOfFirstString:@"1234" andSecondString:@"xyz1234"], @"Detect any common suffix. Whole case.");
+}
+
+- (void)testDiffCommonSuffixDoesntSplitSurrogatePairs {
+    DiffMatchPatch *dmp = [DiffMatchPatch new];
+
+    NSString *pristine = @"☺️🖖🏿";
+    NSString *edited = @"☺️😃🖖🏿";
+    NSString *expected = @"🖖🏿";
+
+    NSUInteger suffix = [dmp diff_commonSuffixOfFirstString:pristine andSecondString:edited];
+    NSString *common = [pristine substringFromIndex:pristine.length - suffix];
+
+    XCTAssertEqualObjects(expected, common, @"Common Suffix should match the last emoji");
 }
 
 - (void)testDiffCommonOverlapTest {


### PR DESCRIPTION
### Details:
In this PR we're upgrading DiffMatchPatch so that surrogate pairs are not cut in half.
This avoids invalid unicode strings to be formed.

[Simplenote sibling here](https://github.com/Automattic/simplenote-macos/issues/397)
Closes #580

### Testing:
[TBD]
