### PR TITLE
Bugfix: DiffMatchPatch Surrogate Pairs Support

### DIFF
--- a/External/diffmatchpatch/DiffMatchPatch.m
+++ b/External/diffmatchpatch/DiffMatchPatch.m
@@ -1503,7 +1503,23 @@ NS_INLINE NSString * diff_charsToTokenString(NSString *charsString, NSArray *tok
 - (NSString *)diff_toDelta:(NSMutableArray *)diffs;
 {
   NSMutableString *delta = [NSMutableString string];
+  unichar lastEnd = 0;
+
   for (Diff *aDiff in diffs) {
+
+    unichar thisTop = [aDiff.text characterAtIndex:0];
+    unichar thisEnd = [aDiff.text characterAtIndex:(aDiff.text.length - 1)];
+
+    if (CFStringIsSurrogateHighCharacter(thisEnd)) {
+        aDiff.text = [aDiff.text substringToIndex:(aDiff.text.length - 1)];
+    }
+
+    if (lastEnd != 0 && CFStringIsSurrogateHighCharacter(lastEnd) && CFStringIsSurrogateLowCharacter(thisTop)) {
+        aDiff.text = [NSString stringWithFormat:@"%C%@", lastEnd, aDiff.text];
+    }
+
+    lastEnd = thisEnd;
+
     switch (aDiff.operation) {
       case DIFF_INSERT:
         [delta appendFormat:@"+%@\t", [[aDiff.text diff_stringByAddingPercentEscapesForEncodeUriCompatibility]

--- a/External/diffmatchpatch/DiffMatchPatch.m
+++ b/External/diffmatchpatch/DiffMatchPatch.m
@@ -1519,6 +1519,9 @@ NS_INLINE NSString * diff_charsToTokenString(NSString *charsString, NSArray *tok
     }
 
     lastEnd = thisEnd;
+    if (0 == [aDiff.text length]) {
+      continue;
+    }
 
     switch (aDiff.operation) {
       case DIFF_INSERT:

--- a/Simperium/SPEnvironment.m
+++ b/Simperium/SPEnvironment.m
@@ -30,7 +30,7 @@ NSString* const SPLibraryID = @"osx";
 #endif
 
 // TODO: Update this automatically via a script that looks at current git tag
-NSString* const SPLibraryVersion = @"0.8.23";
+NSString* const SPLibraryVersion = @"0.8.24";
 
 /// SSL Pinning
 ///

--- a/SimperiumTests/DiffMatchPatchTest.m
+++ b/SimperiumTests/DiffMatchPatchTest.m
@@ -64,7 +64,7 @@
 - (void)testDiffToDeltaWithEmojisCanBeProperlyAppliedToOriginalString {
   DiffMatchPatch *dmp = [DiffMatchPatch new];
 
-    NSString *pristine = @"☺️🖖🏿";
+  NSString *pristine = @"☺️🖖🏿";
   NSString *edited = @"☺️😃🖖🏿";
 
   NSMutableArray *diffs = [dmp diff_mainOfOldString:pristine andNewString:edited];

--- a/SimperiumTests/DiffMatchPatchTest.m
+++ b/SimperiumTests/DiffMatchPatchTest.m
@@ -48,6 +48,33 @@
   XCTAssertEqual((NSUInteger)4, [dmp diff_commonPrefixOfFirstString:@"1234" andSecondString:@"1234xyz"], @"Common suffix whole case failed.");
 }
 
+- (void)testDiffToDeltaDoesNotProduceNullsWhenDealingWithEmojis {
+  DiffMatchPatch *dmp = [DiffMatchPatch new];
+
+  NSString *pristine = @"☺️🖖🏿";
+  NSString *edited = @"☺️😃🖖🏿";
+  NSString *expected = @"=2\t+%F0%9F%98%83\t=4";
+
+  NSMutableArray *diffs = [dmp diff_mainOfOldString:pristine andNewString:edited];
+  NSString *delta = [dmp diff_toDelta:diffs];
+
+  XCTAssertEqualObjects(delta, expected, @"Delta should match the expected string");
+}
+
+- (void)testDiffToDeltaWithEmojisCanBeProperlyAppliedToOriginalString {
+  DiffMatchPatch *dmp = [DiffMatchPatch new];
+
+    NSString *pristine = @"☺️🖖🏿";
+  NSString *edited = @"☺️😃🖖🏿";
+
+  NSMutableArray *diffs = [dmp diff_mainOfOldString:pristine andNewString:edited];
+  NSArray *patches = [dmp patch_makeFromDiffs:diffs];
+  NSArray *result = [dmp patch_apply:patches toString:pristine];
+
+  NSString *output = [result firstObject];
+  XCTAssertEqualObjects(edited, output, @"Output String should match the Edited one!");
+}
+
 - (void)testDiffCommonSuffixTest {
   DiffMatchPatch *dmp = [DiffMatchPatch new];
 


### PR DESCRIPTION
### Details:
In this PR we're upgrading DiffMatchPatch so that diffs that contain Surrogate Pairs are fixed on the fly, and thus, we don't produce invalid unicode strings.

[Simplenote sibling here](https://github.com/Automattic/simplenote-macos/issues/397)
[Upstream sibling here](https://github.com/google/diff-match-patch/pull/80/files)

H/T @dmsnell for literally fixing this bug in 5 different platforms / languages (Thank you Dennis!!).

Closes #580

### Testing:
- [ ] Verify the (new) unit tests are green!