### PR TITLE
DiffMatchPatch: Fixing Breaking Scenario

### DIFF
--- a/External/diffmatchpatch/DiffMatchPatch.m
+++ b/External/diffmatchpatch/DiffMatchPatch.m
@@ -1507,19 +1507,23 @@ NS_INLINE NSString * diff_charsToTokenString(NSString *charsString, NSArray *tok
 
   for (Diff *aDiff in diffs) {
 
-    unichar thisTop = [aDiff.text characterAtIndex:0];
-    unichar thisEnd = [aDiff.text characterAtIndex:(aDiff.text.length - 1)];
+    if (0 == [aDiff.text length]) {
+      continue;
+    }
+
+    UniChar thisTop = [aDiff.text characterAtIndex:0];
+    UniChar thisEnd = [aDiff.text characterAtIndex:([aDiff.text length] - 1)];
 
     if (CFStringIsSurrogateHighCharacter(thisEnd)) {
-        aDiff.text = [aDiff.text substringToIndex:(aDiff.text.length - 1)];
+      lastEnd = thisEnd;
+      aDiff.text = [aDiff.text substringToIndex:([aDiff.text length] - 1)];
     }
 
     if (lastEnd != 0 && CFStringIsSurrogateHighCharacter(lastEnd) && CFStringIsSurrogateLowCharacter(thisTop)) {
-        aDiff.text = [NSString stringWithFormat:@"%C%@", lastEnd, aDiff.text];
+      aDiff.text = [NSString stringWithFormat:@"%C%@", lastEnd, aDiff.text];
     }
 
-    lastEnd = thisEnd;
-    if (0 == [aDiff.text length]) {
+    if ([aDiff.text length] == 0) {
       continue;
     }
 

--- a/SimperiumTests/DiffMatchPatchTest.m
+++ b/SimperiumTests/DiffMatchPatchTest.m
@@ -61,6 +61,21 @@
   XCTAssertEqualObjects(delta, expected, @"Delta should match the expected string");
 }
 
+- (void)testDiffToDeltaDoesCrashOnEmptyTextDiffs {
+  DiffMatchPatch *dmp = [DiffMatchPatch new];
+
+  NSString *pristine = @"😃🖖🏻🖖🏻🖖🏿\n🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉\n\n.👉🏽👉🏽👉🏽👉🏽👉🏽👉🏽👉🏽👉🏽👉🏽s👈🏿👈🏿👈🏿👈🏿👈🏿👈🏿👈🏿👈🏿👈🏿.\n🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉\n.👉🏽👈🏿👈🏿👈🏿🥶🥶🥶🥶🥶👈🏼🖖🏻👈🏼s🖖🏻👈🏼😋\n\ndasdas\ndasvafksdldasfadsxc vzx";
+  NSString *edited = @"😃🖖🏻🖖🏻🖖🏿\n🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉\nfds\n.👉🏽👉🏽👉🏽👉🏽👉🏽👉🏽👉🏽👉🏽👉🏽s👈🏿👈🏿👈🏿👈🏿👈🏿👈🏿👈🏿👈🏿👈🏿.\n🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉fdsvadsfewdsfdsafsdafsd";
+
+  NSMutableArray *diffs = [dmp diff_mainOfOldString:pristine andNewString:edited];
+  if (diffs.count > 2) {
+    [dmp diff_cleanupSemantic:diffs];
+    [dmp diff_cleanupEfficiency:diffs];
+  }
+
+  XCTAssertNoThrow([dmp diff_toDelta:diffs]);
+}
+
 - (void)testDiffToDeltaWithEmojisCanBeProperlyAppliedToOriginalString {
   DiffMatchPatch *dmp = [DiffMatchPatch new];
 


### PR DESCRIPTION
### Details:
We've been getting reports of a DiffMatchPatch-Y crash on [Simplenote macOS](https://github.com/Automattic/simplenote-macos/issues/419).

We've replicated the crash in a new Unit Test. **Fix pending analysis**, we'll need to deploy a cross platform patch.

### Testing:
- [ ] Verify the new DiffMatchPatch Tests turn green!