### PR TITLE
Reloading Inconsistent Entities

### DIFF
--- a/Simperium.xcodeproj/project.pbxproj
+++ b/Simperium.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		B57FA3AE190052C800957205 /* MockStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = B57FA3AD190052C800957205 /* MockStorage.m */; };
 		B57FA3B21900568A00957205 /* SPRelationshipResolverTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B57FA3B11900568A00957205 /* SPRelationshipResolverTests.m */; };
 		B597DD59183128FE005E95D7 /* SPWebSocketInterfaceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B597DD58183128FE005E95D7 /* SPWebSocketInterfaceTests.m */; };
+		B59FA73723A96F0C005EC42C /* NSDictionarySimperiumTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B59FA73623A96F0C005EC42C /* NSDictionarySimperiumTests.m */; };
 		B5A57EAC1951C128006E2455 /* SPIndexProcessorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B5A57EAB1951C128006E2455 /* SPIndexProcessorTests.m */; };
 		B5A8773422DCD37F00FC22C7 /* SPAuthenticationInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = B5A8773322DCD37F00FC22C7 /* SPAuthenticationInterface.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B5A8773522DCD37F00FC22C7 /* SPAuthenticationInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = B5A8773322DCD37F00FC22C7 /* SPAuthenticationInterface.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -603,6 +604,7 @@
 		B58B22E31905A1B200190E90 /* SPRelationship.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPRelationship.h; sourceTree = "<group>"; };
 		B58B22E41905A1B200190E90 /* SPRelationship.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPRelationship.m; sourceTree = "<group>"; };
 		B597DD58183128FE005E95D7 /* SPWebSocketInterfaceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = SPWebSocketInterfaceTests.m; sourceTree = "<group>"; };
+		B59FA73623A96F0C005EC42C /* NSDictionarySimperiumTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSDictionarySimperiumTests.m; sourceTree = "<group>"; };
 		B5A0136A18312852003D4620 /* UnitTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "UnitTests-Info.plist"; sourceTree = "<group>"; };
 		B5A0136C1831285A003D4620 /* IntegrationTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "IntegrationTests-Info.plist"; sourceTree = "<group>"; };
 		B5A19D5718806BBC0059AA36 /* SPWebSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = SPWebSocket.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
@@ -1217,6 +1219,7 @@
 		B5ECEA2218310DF700B9289A /* UnitTests */ = {
 			isa = PBXGroup;
 			children = (
+				B59FA73623A96F0C005EC42C /* NSDictionarySimperiumTests.m */,
 				B5A57EAB1951C128006E2455 /* SPIndexProcessorTests.m */,
 				B51397F01947612B004C1416 /* SPChangeProcessorTests.m */,
 				B5C7D7F8183411B900E9109C /* SPPersistentMutableDictionaryTests.m */,
@@ -1872,6 +1875,7 @@
 				B5DF229518B41FB700874C75 /* SPMemberJSONTests.m in Sources */,
 				B51397F11947612B004C1416 /* SPChangeProcessorTests.m in Sources */,
 				B597DD59183128FE005E95D7 /* SPWebSocketInterfaceTests.m in Sources */,
+				B59FA73723A96F0C005EC42C /* NSDictionarySimperiumTests.m in Sources */,
 				B5B69C0318325B2C001F0DE1 /* MockSimperium.m in Sources */,
 				B5F3C60D1A84FA49000CE940 /* SPManagedObjectTests.m in Sources */,
 				B5549FE6184581BF007EA226 /* SPThreadsafeMutableSetTests.m in Sources */,

--- a/Simperium/JSONKit+Simperium.h
+++ b/Simperium/JSONKit+Simperium.h
@@ -17,6 +17,7 @@
 @end
 
 @interface NSDictionary (SPJSONKitAdapterCategories)
+- (BOOL)sp_isValidJsonObject;
 - (NSString *)sp_JSONString;
 - (NSString *)sp_JSONStringWithError:(NSError **)error;
 @end

--- a/Simperium/JSONKit+Simperium.m
+++ b/Simperium/JSONKit+Simperium.m
@@ -95,6 +95,11 @@ static NSJSONWritingOptions const SPJSONWritingOptions = 0;
 
 @implementation NSDictionary (SPJSONKitAdapterCategories)
 
+- (BOOL)sp_isValidJsonObject
+{
+    return [NSJSONSerialization isValidJSONObject:self];
+}
+
 - (NSString *)sp_JSONString
 {
     return [NSJSONSerialization sp_JSONStringFromObject:self error:nil];

--- a/Simperium/SPChangeProcessor.h
+++ b/Simperium/SPChangeProcessor.h
@@ -25,6 +25,7 @@ typedef NS_ENUM(NSInteger, SPProcessorErrors) {
     SPProcessorErrorsSentInvalidChange,         // Send Full Data: The backend couldn't apply our diff
     SPProcessorErrorsReceivedUnknownChange,     // No need to handle: We've received a change for an unknown entity
     SPProcessorErrorsReceivedInvalidChange,     // Should Redownload the Entity: We couldn't apply a remote diff
+    SPProcessorErrorsEntityGhostIntegrity,      // Entity's Ghost Integrity has been compromised. We'll reload the remote entity
     SPProcessorErrorsClientOutOfSync,           // We received a change with an SV != local version: Reindex is required
     SPProcessorErrorsClientError,               // Should Nuke PendingChange: Catch-all client errors
     SPProcessorErrorsServerError                // Should Retry: Catch-all server errors

--- a/Simperium/SPChangeProcessor.m
+++ b/Simperium/SPChangeProcessor.m
@@ -299,7 +299,16 @@ static int const SPChangeProcessorMaxPendingChanges = 200;
         }
         
         object.ghost.version = endVersion;
-        
+
+        // Ensure the Ghost's Integrity: On error we'll reload the entity
+        if (object.ghost.dictionary != nil && [object.ghost.dictionary sp_isValidJsonObject] == false) {
+            SPLogError(@"Simperium Error: Ghost Integrity Check Failure");
+            if (error) {
+                *error = [NSError sp_errorWithDomain:NSStringFromClass([self class]) code:SPProcessorErrorsEntityGhostIntegrity description:theError.description];
+            }
+            return NO;
+        }
+
         // Slight hack to ensure Core Data realizes the object has changed and needs a save
         NSString *ghostDataCopy = [[[object.ghost dictionary] sp_JSONString] copy];
         object.ghostData        = ghostDataCopy;

--- a/Simperium/SPWebSocketChannel.m
+++ b/Simperium/SPWebSocketChannel.m
@@ -382,7 +382,12 @@ typedef void(^SPWebSocketSyncedBlockType)(void);
         } else if (error.code == SPProcessorErrorsSentInvalidChange) {
             [changeProcessor enqueueObjectForRetry:simperiumKey bucket:bucket overrideRemoteData:YES];
             [indexProcessor disableRebaseForObjectWithKey:simperiumKey];
-            
+
+        } else if (error.code == SPProcessorErrorsEntityGhostIntegrity) {
+            [indexProcessor disableRebaseForObjectWithKey:simperiumKey];
+            [changeProcessor discardPendingChanges:simperiumKey bucket:bucket];
+            [changeProcessor enqueueObjectForRetry:simperiumKey bucket:bucket overrideRemoteData:YES];
+
         } else if (error.code == SPProcessorErrorsServerError) {
             [changeProcessor enqueueObjectForRetry:simperiumKey bucket:bucket overrideRemoteData:NO];
             

--- a/SimperiumTests/NSDictionarySimperiumTests.m
+++ b/SimperiumTests/NSDictionarySimperiumTests.m
@@ -1,0 +1,37 @@
+//
+//  NSDictionarySimperiumTests.m
+//  UnitTests
+//
+//  Created by Jorge Leandro Perez on 12/17/19.
+//  Copyright © 2019 Simperium. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "JSONKit+Simperium.h"
+
+@interface NSDictionarySimperiumTests : XCTestCase
+
+@end
+
+@implementation NSDictionarySimperiumTests
+
+- (void)testStringsContainingBrokenSurrogatePairsAreDetectedAsInvalidObject {
+    NSString *invalid = [NSString stringWithFormat:@"%C%C%C%C%C%C%C%C%C%C%C%C", 9786, 65039, 55357, 40, 110, 117, 108, 108, 41, 56726, 55356, 57343];
+    NSDictionary *invalidObject = @{
+        @"content": invalid,
+    };
+
+    XCTAssertFalse([invalidObject sp_isValidJsonObject], @"Dictionary is expected not to be a valid json");
+}
+
+- (void)testWellFormedStringsArentDetectedAsInvalidObjects {
+    NSDictionary *invalidObject = @{
+        @"content": @{
+            @"UUID": [[NSUUID new] UUIDString]
+        }
+    };
+
+    XCTAssertTrue([invalidObject sp_isValidJsonObject], @"Dictionary is expected to be a valid json");
+}
+
+@end


### PR DESCRIPTION
### Details:
In this PR we're adding an error handling mechanism, capable of detecting Ghost(s) in inconsistent states, and triggering a full entity re-download.

cc @bummytime 
cc @dmsnell 

Closes #584

### Testing:
1. Check out Simplenote iOS
2. Map Simperium's dependency to commit bbcbc91 (this branch, latest!)
3. Comment out DiffMatchPach.m [L1510](https://github.com/Simperium/simperium-ios/blob/develop/External/diffmatchpatch/DiffMatchPatch.m#L1510) thru [L1528](https://github.com/Simperium/simperium-ios/blob/develop/External/diffmatchpatch/DiffMatchPatch.m#L1528)
4. Clean + Rebuild
5. Log into your account
6. Add a new note
7. Insert the following emojis: ☺️🖖🏿
8. Insert the following emoji in between: 😃

- [x] Verify Simplenote does not crash
- [ ] Verify that (after a second) you end up with `☺️😃(null)🖖🏿` onscreen

**Note**:
- The purpose of this fix is to **prevent** the app from entering a crashloop, caused by NSJSONSerialization while attempting to serialize a broken string, and recover by performing a full entity re-download
- The actual underlying bug has been already fixed via #583 and #582
