### PR TITLE
SPAuthenticator: New Validation API

### DIFF
--- a/Simperium/SPAuthenticator.h
+++ b/Simperium/SPAuthenticator.h
@@ -38,9 +38,24 @@ typedef void(^FailedBlockType)(int responseCode, NSString *responseString);
 @property (nonatomic, assign,  readonly) BOOL       connected;
 
 - (instancetype)initWithDelegate:(id<SPAuthenticatorDelegate>)authDelegate simperium:(Simperium *)s;
+
 - (BOOL)authenticateIfNecessary;
-- (void)authenticateWithUsername:(NSString *)username password:(NSString *)password success:(SucceededBlockType)successBlock failure:(FailedBlockType)failureBlock;
-- (void)createWithUsername:(NSString *)username password:(NSString *)password success:(SucceededBlockType)successBlock failure:(FailedBlockType)failureBlock;
+
+- (void)authenticateWithUsername:(NSString *)username
+                        password:(NSString *)password
+                         success:(SucceededBlockType)successBlock
+                         failure:(FailedBlockType)failureBlock;
+
+- (void)validateWithUsername:(NSString *)username
+                    password:(NSString *)password
+                     success:(SucceededBlockType)successBlock
+                     failure:(FailedBlockType)failureBlock;
+
+- (void)createWithUsername:(NSString *)username
+                  password:(NSString *)password
+                   success:(SucceededBlockType)successBlock
+                   failure:(FailedBlockType)failureBlock;
+
 - (void)reset;
 - (void)cancel;
 


### PR DESCRIPTION
### Details:
In this PR we're adding a new Credentials Validation API: We're calling the exact same backend API that deals with Authentication... **but** instead of initializing the internal state (and opening the WebSocket), we'll callback with a Success / Failure state.

### Testing:
Details outlined in [Simplenote PR 747](https://github.com/Automattic/simplenote-ios/pull/747)

@aerych May I bug you with this one?
Thank you sir!!