### PR TITLE
Upgrading Concurrency Type

### DIFF
--- a/Simperium/SPChangeProcessor.m
+++ b/Simperium/SPChangeProcessor.m
@@ -198,7 +198,8 @@ static int const SPChangeProcessorMaxPendingChanges = 200;
 {
     id<SPStorageProvider> threadSafeStorage = [bucket.storage threadSafeStorage];
     __block BOOL success                    = NO;
-    
+    __block NSError *innerError             = nil;
+
     [threadSafeStorage performSafeBlockAndWait:^{
         success = [self _processRemoteModifyWithKey:simperiumKey
                                              bucket:bucket
@@ -206,8 +207,12 @@ static int const SPChangeProcessorMaxPendingChanges = 200;
                                              change:change
                                        acknowledged:acknowledged
                                       clientMatches:clientMatches
-                                              error:error];
+                                              error:&innerError];
     }];
+
+    if (innerError != nil && error != nil) {
+        *error = innerError;
+    }
     
     return success;
 }


### PR DESCRIPTION
### Description:
Apple dropped iOS 8 support in Xcode 12. As a result, we're getting a wonderful warning, indicating that CoreData's Thread Confinement has been deprecated.

In this PR we're switching over a Private Queue model.

@astralbodies Caaan I bother you a biiit?

Thaaank you!!!

### Architecture:
Our Core Data architecture is exactly the same as ever:

- Stack = **Main MOC**  >> **Writer MOC** >> **Persistent Storage**
- Workers = **Private Queue MOC** >> **Persistent Storage**

**CoreDataStorage**'s `threadsafeStorage` API is now returning a Private Queue MOC, rather than a Thread Confined MOC.

### Critical Section API
In PR #438 (six years ago!!) we've implemented a "Critical Section" API, to ensure Object Deletions are never processed concurrently along with Insertions / Updates. 

Since **all of the operations** performed over **CoreDataStorage.threadsafeStorage** instances were already wrapped up by `performSafeBlockAndWait` / `performCriticalBlockAndWait`, we just needed to patch two tiny spots.

### Testing:
Please:

- [ ] Verify Unit Tests look good
- [ ] Verify the changes make sense!!
- [ ] Verify [Simplenote PR 877](https://github.com/Automattic/simplenote-ios/pull/877) looks good

Thaaank you :smile:
