### PR TITLE
Persistent Dictionary: Secure Coding Support

### DIFF
--- a/Simperium/SPPersistentMutableDictionary.h
+++ b/Simperium/SPPersistentMutableDictionary.h
@@ -17,6 +17,7 @@
 @interface SPPersistentMutableDictionary : NSObject
 
 @property (nonatomic, strong, readonly) NSString *label;
+@property (nonatomic, strong, readwrite) NSSet *supportedObjectTypes;
 
 - (NSInteger)count;
 - (BOOL)containsObjectForKey:(id)aKey;

--- a/Simperium/SPPersistentMutableDictionary.h
+++ b/Simperium/SPPersistentMutableDictionary.h
@@ -26,6 +26,7 @@
 @property (nonatomic, strong, readwrite) NSSet<Class> *supportedObjectTypes;
 
 /// Indicates if the stored `Supported Object Types` should be required to conform to NSCoding. Defaults to YES
+/// - Important: Only used for Unit Testing purposes!
 ///
 @property (nonatomic, assign, readwrite) BOOL requiringSecureCoding;
 

--- a/Simperium/SPPersistentMutableDictionary.h
+++ b/Simperium/SPPersistentMutableDictionary.h
@@ -16,14 +16,32 @@
 
 @interface SPPersistentMutableDictionary : NSObject
 
+/// The Dictionary's Label is used to define the Persistent Store identifier. Different labels will map to different persistent databases.
+///
 @property (nonatomic, strong, readonly) NSString *label;
+
+/// Specifies the Supported Types
+///
 @property (nonatomic, strong, readwrite) NSSet *supportedObjectTypes;
 
+/// Returns the total number of stored entities
+///
 - (NSInteger)count;
+
+/// Indicates if there's an object associated ot the specified Key
+///
 - (BOOL)containsObjectForKey:(id)aKey;
 
+/// Returns an object associated to the specified Key. Note that the resulting Object Type will be constrained by the `supportedObjectTypes` collection
+///
 - (id)objectForKey:(NSString*)aKey;
+
+/// Stores the specified Object. Please note that the Object's Type must be specified by the `supportedObjectTypes` collection
+///
 - (void)setObject:(id)anObject forKey:(NSString*)aKey;
+
+/// Persists the internal stack
+///
 - (BOOL)save;
 
 - (NSArray*)allKeys;

--- a/Simperium/SPPersistentMutableDictionary.h
+++ b/Simperium/SPPersistentMutableDictionary.h
@@ -21,8 +21,14 @@
 @property (nonatomic, strong, readonly) NSString *label;
 
 /// Specifies the Supported Types
+/// - Note: All classes specified here must conform to NSSecureCoding
 ///
-@property (nonatomic, strong, readwrite) NSSet *supportedObjectTypes;
+@property (nonatomic, strong, readwrite) NSSet<Class> *supportedObjectTypes;
+
+/// Indicates if the stored `Supported Object Types` should be required to conform to NSCoding. Defaults to YES
+///
+@property (nonatomic, assign, readwrite) BOOL requiringSecureCoding;
+
 
 /// Returns the total number of stored entities
 ///

--- a/Simperium/SPPersistentMutableDictionary.m
+++ b/Simperium/SPPersistentMutableDictionary.m
@@ -47,7 +47,8 @@ static SPLogLevels logLevel                 = SPLogLevelsError;
     self = [super init];
     if (self) {
         self.label = label;
-        self.cache = [[NSCache alloc] init];
+        self.cache = [NSCache new];
+        self.requiringSecureCoding = YES;
         self.supportedObjectTypes = [NSSet setWithArray:@[
             [NSDictionary class],
             [NSArray class],
@@ -116,7 +117,9 @@ static SPLogLevels logLevel                 = SPLogLevelsError;
             // Unarchive
             id archivedValue = [object valueForKey:SPDictionaryEntityValue];
             if (archivedValue) {
-                value = [NSKeyedUnarchiver unarchiveObjectWithData:archivedValue];
+                value = [NSKeyedUnarchiver unarchivedObjectOfClasses:self.supportedObjectTypes
+                                                            fromData:archivedValue
+                                                               error:nil];
             }
         }
     }];
@@ -136,6 +139,8 @@ static SPLogLevels logLevel                 = SPLogLevelsError;
         return;
     }
 
+    NSAssert([self canStoreObject:anObject], @"Unsupported Object Type");
+
     [self.managedObjectContext performBlock:^{
         
         NSError *error = nil;
@@ -151,9 +156,11 @@ static SPLogLevels logLevel                 = SPLogLevelsError;
             change = [NSEntityDescription insertNewObjectForEntityForName:SPDictionaryEntityName inManagedObjectContext:self.managedObjectContext];
             [change setValue:aKey forKey:SPDictionaryEntityKey];
         }
-        
+
         // Wrap up the value
-        id archivedValue = [NSKeyedArchiver archivedDataWithRootObject:anObject];
+        id archivedValue = [NSKeyedArchiver archivedDataWithRootObject:anObject
+                                                 requiringSecureCoding:self.requiringSecureCoding
+                                                                 error:nil];
         [change setValue:archivedValue forKey:SPDictionaryEntityValue];
     }];
     
@@ -439,7 +446,7 @@ static SPLogLevels logLevel                 = SPLogLevelsError;
 }
 
 - (NSArray *)loadObjectsProperty:(NSString*)property unarchive:(BOOL)unarchive {
-    NSMutableArray *keys = [NSMutableArray array];
+    NSMutableArray *output = [NSMutableArray array];
     
     [self.managedObjectContext performBlockAndWait:^{
         
@@ -455,15 +462,31 @@ static SPLogLevels logLevel                 = SPLogLevelsError;
                 continue;
             }
             
-            if (unarchive) {
-                [keys addObject:[NSKeyedUnarchiver unarchiveObjectWithData:value]];
-            } else {
-                [keys addObject:value];
+            if (!unarchive) {
+                [output addObject:value];
+                continue;;
+            }
+
+            id decodedValue = [NSKeyedUnarchiver unarchivedObjectOfClasses:self.supportedObjectTypes
+                                                                  fromData:value
+                                                                     error:nil];
+            if (decodedValue) {
+                [output addObject:decodedValue];
             }
         }
     }];
     
-    return keys;
+    return output;
+}
+
+- (BOOL)canStoreObject:(id)anObject {
+    for (Class supportedClass in self.supportedObjectTypes) {
+        if ([anObject isKindOfClass:supportedClass]) {
+            return YES;
+        }
+    }
+
+    return NO;
 }
 
 @end

--- a/Simperium/SPPersistentMutableDictionary.m
+++ b/Simperium/SPPersistentMutableDictionary.m
@@ -245,12 +245,12 @@ static SPLogLevels logLevel                 = SPLogLevelsError;
         
         // Dynamic Attributes
         NSAttributeDescription *keyAttribute    = [[NSAttributeDescription alloc] init];
-        keyAttribute.name                       = @"key";
+        keyAttribute.name                       = SPDictionaryEntityKey;
         keyAttribute.attributeType              = NSStringAttributeType;
         keyAttribute.optional                   = NO;
 
         NSAttributeDescription *valueAttribute  = [[NSAttributeDescription alloc] init];
-        valueAttribute.name                     = @"value";
+        valueAttribute.name                     = SPDictionaryEntityValue;
         valueAttribute.attributeType            = NSBinaryDataAttributeType;
         valueAttribute.optional                 = NO;
 

--- a/Simperium/SPPersistentMutableDictionary.m
+++ b/Simperium/SPPersistentMutableDictionary.m
@@ -48,6 +48,11 @@ static SPLogLevels logLevel                 = SPLogLevelsError;
     if (self) {
         self.label = label;
         self.cache = [[NSCache alloc] init];
+        self.supportedObjectTypes = [NSSet setWithArray:@[
+            [NSDictionary class],
+            [NSArray class],
+            [NSString class]
+        ]];
     }
     
     return self;


### PR DESCRIPTION
### Details:
In this PR we're patching up **SPPersistentMutableDictionary** so that it supports the new Secure Coding API.

@eshurakov May I bug you with this one as well?
Thank you!!

Closes #603

### Note:
The flag `requiresSecureCoding` (NSKeyedArchiver / NSKeyedUnarchiver), as per the documentation, will enforce that persisted / restored classes conform to NSSecureCoding.

However, it does not allow us to turn On / Off encryption. For such reason, a migration is not necessary.

```
If you set the receiver to require secure coding, it will throw an exception if you attempt to unarchive a class which does not conform to NSSecureCoding.
```

**Plus:** A new Unit Test has been added to verify that "Unsecure Archives" can be opened when this flag is On.

### Testing:
- [ ] Refer to [This Simplenote PR](https://github.com/Automattic/simplenote-ios/pull/986) to verify these changes
- [ ] Verify the code looks good please!
