### PR TITLE
Enabling JSONStorage Support

### DIFF
--- a/Simperium.xcodeproj/project.pbxproj
+++ b/Simperium.xcodeproj/project.pbxproj
@@ -52,6 +52,11 @@
 		B57421D52510FA67006F2A71 /* NSURLRequest+Simperium.h in Headers */ = {isa = PBXBuildFile; fileRef = B57421D22510FA67006F2A71 /* NSURLRequest+Simperium.h */; };
 		B57421D62510FA67006F2A71 /* NSURLRequest+Simperium.m in Sources */ = {isa = PBXBuildFile; fileRef = B57421D32510FA67006F2A71 /* NSURLRequest+Simperium.m */; };
 		B57421D72510FA67006F2A71 /* NSURLRequest+Simperium.m in Sources */ = {isa = PBXBuildFile; fileRef = B57421D32510FA67006F2A71 /* NSURLRequest+Simperium.m */; };
+		B57CFA1C25B10B7100ABA284 /* SPThreadsafeMutableDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = B57CFA1A25B10B7100ABA284 /* SPThreadsafeMutableDictionary.h */; };
+		B57CFA1D25B10B7100ABA284 /* SPThreadsafeMutableDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = B57CFA1A25B10B7100ABA284 /* SPThreadsafeMutableDictionary.h */; };
+		B57CFA1E25B10B7100ABA284 /* SPThreadsafeMutableDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = B57CFA1B25B10B7100ABA284 /* SPThreadsafeMutableDictionary.m */; };
+		B57CFA1F25B10B7100ABA284 /* SPThreadsafeMutableDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = B57CFA1B25B10B7100ABA284 /* SPThreadsafeMutableDictionary.m */; };
+		B57CFA2925B1100600ABA284 /* SPThreadsafeMutableDictionaryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B57CFA2825B1100600ABA284 /* SPThreadsafeMutableDictionaryTests.m */; };
 		B57FA3AE190052C800957205 /* MockStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = B57FA3AD190052C800957205 /* MockStorage.m */; };
 		B57FA3B21900568A00957205 /* SPRelationshipResolverTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B57FA3B11900568A00957205 /* SPRelationshipResolverTests.m */; };
 		B585125A2485FE32002BD70C /* SPAuthenticationValidatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B58512592485FE32002BD70C /* SPAuthenticationValidatorTests.m */; };
@@ -603,6 +608,9 @@
 		B5728F9B250FD4A700D1DA07 /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk/System/Library/Frameworks/CoreServices.framework; sourceTree = DEVELOPER_DIR; };
 		B57421D22510FA67006F2A71 /* NSURLRequest+Simperium.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSURLRequest+Simperium.h"; sourceTree = "<group>"; };
 		B57421D32510FA67006F2A71 /* NSURLRequest+Simperium.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSURLRequest+Simperium.m"; sourceTree = "<group>"; };
+		B57CFA1A25B10B7100ABA284 /* SPThreadsafeMutableDictionary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPThreadsafeMutableDictionary.h; sourceTree = "<group>"; };
+		B57CFA1B25B10B7100ABA284 /* SPThreadsafeMutableDictionary.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPThreadsafeMutableDictionary.m; sourceTree = "<group>"; };
+		B57CFA2825B1100600ABA284 /* SPThreadsafeMutableDictionaryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPThreadsafeMutableDictionaryTests.m; sourceTree = "<group>"; };
 		B57FA3AC190052C800957205 /* MockStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MockStorage.h; sourceTree = "<group>"; };
 		B57FA3AD190052C800957205 /* MockStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MockStorage.m; sourceTree = "<group>"; };
 		B57FA3B11900568A00957205 /* SPRelationshipResolverTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPRelationshipResolverTests.m; sourceTree = "<group>"; };
@@ -900,6 +908,8 @@
 				24A73F5517E250E0000CA275 /* SPPersistentMutableDictionary.m */,
 				B5EC2C2318858E3E0067E3B8 /* SPPersistentMutableSet.h */,
 				B5EC2C2418858E3E0067E3B8 /* SPPersistentMutableSet.m */,
+				B57CFA1A25B10B7100ABA284 /* SPThreadsafeMutableDictionary.h */,
+				B57CFA1B25B10B7100ABA284 /* SPThreadsafeMutableDictionary.m */,
 				B5549FE118457F72007EA226 /* SPThreadsafeMutableSet.h */,
 				B5549FE218457F72007EA226 /* SPThreadsafeMutableSet.m */,
 				B5EB86981822E34F007450FF /* SPLogger.h */,
@@ -1232,6 +1242,7 @@
 				B5C7D7F8183411B900E9109C /* SPPersistentMutableDictionaryTests.m */,
 				B5EC2C27188595420067E3B8 /* SPPersistentMutableSetTests.m */,
 				B5549FE5184581BF007EA226 /* SPThreadsafeMutableSetTests.m */,
+				B57CFA2825B1100600ABA284 /* SPThreadsafeMutableDictionaryTests.m */,
 				B597DD58183128FE005E95D7 /* SPWebSocketInterfaceTests.m */,
 				B5DE0E0E1850D0200080C44D /* SPCoreDataStorageTests.m */,
 				B5DF229418B41FB700874C75 /* SPMemberJSONTests.m */,
@@ -1359,6 +1370,7 @@
 				B5FC08BA1D662D5300045DB9 /* TrustKit+Private.h in Headers */,
 				B5CAA4C11CAAB40F006FE048 /* SPNetworkInterface.h in Headers */,
 				B5CAA4C61CAAB44E006FE048 /* SPStorageProvider.h in Headers */,
+				B57CFA1C25B10B7100ABA284 /* SPThreadsafeMutableDictionary.h in Headers */,
 				B5CAA4C01CAAB405006FE048 /* SPUser.h in Headers */,
 				B5CAA4C81CAAB50E006FE048 /* SPSwizzle.h in Headers */,
 				B5FC08A21D662D5300045DB9 /* parse_configuration.h in Headers */,
@@ -1441,6 +1453,7 @@
 				B5F6A4C3251024380001D7E3 /* NSURLSession+Simperium.h in Headers */,
 				B5CAA5BA1CAAED3D006FE048 /* Simperium.h in Headers */,
 				B5A8773522DCD37F00FC22C7 /* SPAuthenticationInterface.h in Headers */,
+				B57CFA1D25B10B7100ABA284 /* SPThreadsafeMutableDictionary.h in Headers */,
 				B5CAA5BC1CAAED3D006FE048 /* SPAuthenticationConfiguration.h in Headers */,
 				B5CAA5BD1CAAED3D006FE048 /* SPAuthenticator.h in Headers */,
 				B5CAA5BE1CAAED3D006FE048 /* SPBucket.h in Headers */,
@@ -1776,6 +1789,7 @@
 				B5CAA5491CAABC16006FE048 /* SPNetworkInterface.m in Sources */,
 				B5CAA54A1CAABC1D006FE048 /* SPProcessorConstants.m in Sources */,
 				B5CAA6511CAAF2F8006FE048 /* SPAuthenticationViewController.m in Sources */,
+				B57CFA1E25B10B7100ABA284 /* SPThreadsafeMutableDictionary.m in Sources */,
 				B5CAA54B1CAABC23006FE048 /* NSError+Simperium.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1860,6 +1874,7 @@
 				B5CAA5AD1CAAED3D006FE048 /* SPNetworkInterface.m in Sources */,
 				B5CAA5AE1CAAED3D006FE048 /* SPProcessorConstants.m in Sources */,
 				B5CAA5AF1CAAED3D006FE048 /* NSError+Simperium.m in Sources */,
+				B57CFA1F25B10B7100ABA284 /* SPThreadsafeMutableDictionary.m in Sources */,
 				B5CAA63E1CAAF1D9006FE048 /* SPAuthenticationButtonCell.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1868,6 +1883,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B57CFA2925B1100600ABA284 /* SPThreadsafeMutableDictionaryTests.m in Sources */,
 				B53F75A91A1BAB4600C0DDFB /* SPStorageObserverAdapter.m in Sources */,
 				B565ECA31832643000D162FF /* TestObject.m in Sources */,
 				B57FA3AE190052C800957205 /* MockStorage.m in Sources */,

--- a/Simperium/SPBucket.m
+++ b/Simperium/SPBucket.m
@@ -158,19 +158,25 @@
 }
 
 - (NSString *)lastChangeSignature {
-    if (!_lastChangeSignature) {
-        // Load it
+    // Load it: Skip for Ephemeral Storage
+    if (!_lastChangeSignature && !_storage.isEphemeral) {
         NSString *sigKey = [NSString stringWithFormat:@"lastChangeSignature-%@", self.instanceLabel];
         NSString *signature = [[NSUserDefaults standardUserDefaults] objectForKey:sigKey];
         _lastChangeSignature = [signature copy];
     }
+
     return _lastChangeSignature;
 }
 
 - (void)setLastChangeSignature:(NSString *)signature {
+
     _lastChangeSignature = [signature copy];
     
-    // Persist it
+    // Persist it: Skip for Ephemeral Storage
+    if (self.storage.isEphemeral) {
+        return;
+    }
+
     NSString *sigKey = [NSString stringWithFormat:@"lastChangeSignature-%@", self.instanceLabel];
     [[NSUserDefaults standardUserDefaults] setObject:_lastChangeSignature forKey: sigKey];
     [[NSUserDefaults standardUserDefaults] synchronize];

--- a/Simperium/SPCoreDataStorage.m
+++ b/Simperium/SPCoreDataStorage.m
@@ -400,6 +400,10 @@ typedef void (^SPCoreDataStorageSaveCallback)(void);
     return [self.privateStashedObjects copy];
 }
 
+- (BOOL)isEphemeral {
+    return NO;
+}
+
 
 #pragma mark - Stashing and unstashing entities
 

--- a/Simperium/SPDiffable.h
+++ b/Simperium/SPDiffable.h
@@ -10,13 +10,13 @@
 @property (nonatomic, copy) NSString *ghostData;
 @property (nonatomic, copy) NSString *simperiumKey;
 @property (nonatomic, weak) SPBucket *bucket;
+@property (nonatomic, copy, readonly) NSDictionary *dictionary;
+@property (nonatomic, copy, readonly) NSString *version;
 
 - (void)simperiumSetValue:(id)value forKey:(NSString *)key;
 - (id)simperiumValueForKey:(NSString *)key;
 - (void)loadMemberData:(NSDictionary *)data;
 - (void)willBeRead;
-- (NSDictionary *)dictionary;
-- (NSString *)version;
 - (id)object;
 
 @optional

--- a/Simperium/SPDiffer.m
+++ b/Simperium/SPDiffer.m
@@ -121,7 +121,11 @@ static SPLogLevels logLevel = SPLogLevelsInfo;
         if (change == nil) {
             continue;
         }
-        
+
+        // Dynamic Schema: Ensure the Member is available
+        // TODO: Implement Support for Dynamic Members with different encoding
+        [self.schema ensureDynamicMemberExistsForObject:key key:change[OP_VALUE]];
+
         // Make sure the member exists and is tracked by Simperium
         SPMember *member = [self.schema memberForKey:key];
         if (!member) {
@@ -181,6 +185,9 @@ static SPLogLevels logLevel = SPLogLevelsInfo;
         if (change == nil) {
             continue;
         }
+
+        // Dynamic Schema: Ensure the Member is available
+        [self.schema ensureDynamicMemberExistsForObject:change[OP_VALUE] key:key];
         
         // Make sure the member exists and is tracked by Simperium
         SPMember *member = [self.schema memberForKey:key];

--- a/Simperium/SPJSONStorage.m
+++ b/Simperium/SPJSONStorage.m
@@ -14,7 +14,6 @@
 #import "SPBucket+Internals.h"
 #import "SPSchema.h"
 #import "SPDiffer.h"
-#import "SPswizzle.h"
 
 
 @interface NSMutableDictionary ()
@@ -44,10 +43,6 @@
         
         NSString *queueLabel = @"com.simperium.JSONstorage";
         _storageQueue = dispatch_queue_create([queueLabel cStringUsingEncoding:NSUTF8StringEncoding], NULL);
-        
-        NSError *error = nil;
-        [NSMutableDictionary sp_swizzleMethod:@selector(setObject:forKey:) withMethod:@selector(simperiumSetObject:forKey:) error:&error];
-        [NSMutableDictionary sp_swizzleMethod:@selector(setValue:forKey:) withMethod:@selector(simperiumSetValue:forKey:) error:&error];
     }
     
     return self;
@@ -58,8 +53,6 @@
     // Update the schema if applicable
     SPObject *spObject = [_allObjects objectForKey:simperiumKey];
     [spObject.bucket.differ.schema addMemberForObject:value key:key];
-    
-    // TODO: track the change here so saving can be smart    
 }
 
 - (SPStorage *)threadSafeStorage {

--- a/Simperium/SPJSONStorage.m
+++ b/Simperium/SPJSONStorage.m
@@ -10,7 +10,6 @@
 #import "SPObject.h"
 #import "SPGhost.h"
 #import "NSString+Simperium.h"
-#import "NSMutableDictionary+Simperium.h"
 #import "SPBucket+Internals.h"
 #import "SPSchema.h"
 #import "SPDiffer.h"

--- a/Simperium/SPJSONStorage.m
+++ b/Simperium/SPJSONStorage.m
@@ -127,7 +127,9 @@
     
     NSMutableArray *keys = [NSMutableArray arrayWithCapacity:[bucketObjects count]];
     for (id<SPDiffable>object in bucketObjects) {
-        [keys addObject:[object simperiumKey]];
+        if (object.simperiumKey) {
+            [keys addObject:[object simperiumKey]];
+        }
     }
          
     return keys;

--- a/Simperium/SPJSONStorage.m
+++ b/Simperium/SPJSONStorage.m
@@ -292,15 +292,20 @@
     // triggered from the main thread and could take awhile
     
     // Sync all changes: Fake it for now by trying to send all objects
+
+    // TODO: JSONStorage is readonly at this stage.
+    // Local changes should be captured via `didChangeValue:forKey:`
+    /*
     NSMutableSet *updatedObjects = [NSMutableSet set];
     
     for (NSDictionary *objectDict in _objects.allValues) {
         NSArray *objectsAsList = [objectDict allValues];
         [updatedObjects addObjectsFromArray:objectsAsList];
     }
+    */
 
     [_delegate storageWillSave:self deletedObjects:nil];
-    [_delegate storageDidSave:self insertedObjects:nil updatedObjects:updatedObjects];
+    [_delegate storageDidSave:self insertedObjects:nil updatedObjects:nil];
     
     return NO;
 }

--- a/Simperium/SPJSONStorage.m
+++ b/Simperium/SPJSONStorage.m
@@ -111,17 +111,15 @@
     dispatch_sync(_storageQueue, ^{
         NSDictionary *objectDict = [_objects objectForKey:bucketName];
         if (objectDict) {
-            bucketObjects = [_objects allValues];
+            bucketObjects = [objectDict allValues];
             
-            if (predicate)
+            if (predicate) {
                 bucketObjects = [bucketObjects filteredArrayUsingPredicate:predicate];
+            }
         }
     });
-    
-    if (!bucketObjects) {
-        bucketObjects = @[];
-    }
-    return bucketObjects;
+
+    return bucketObjects ?: @[];
 }
 
 - (NSArray *)objectKeysForBucketName:(NSString *)bucketName {

--- a/Simperium/SPJSONStorage.m
+++ b/Simperium/SPJSONStorage.m
@@ -337,6 +337,10 @@
     return nil;
 }
 
+- (BOOL)isEphemeral {
+    return YES;
+}
+
 - (void)stashUnsavedObjects {
     // NO-OP
 }

--- a/Simperium/SPJSONStorage.m
+++ b/Simperium/SPJSONStorage.m
@@ -87,11 +87,7 @@
         }
     });
     
-    if (!someObjects) {
-        someObjects = @[];
-    }
-    
-    return someObjects;
+    return someObjects ?: @[];
 }
 
 - (id)objectAtIndex:(NSUInteger)index bucketName:(NSString *)bucketName {
@@ -121,7 +117,7 @@
     NSMutableArray *keys = [NSMutableArray arrayWithCapacity:[bucketObjects count]];
     for (id<SPDiffable>object in bucketObjects) {
         if (object.simperiumKey) {
-            [keys addObject:[object simperiumKey]];
+            [keys addObject:object.simperiumKey];
         }
     }
          

--- a/Simperium/SPJSONStorage.m
+++ b/Simperium/SPJSONStorage.m
@@ -51,7 +51,7 @@
 - (void)object:(id)object forKey:(NSString *)simperiumKey didChangeValue:(id)value forKey:(NSString *)key {
     // Update the schema if applicable
     SPObject *spObject = [_allObjects objectForKey:simperiumKey];
-    [spObject.bucket.differ.schema addMemberForObject:value key:key];
+    [spObject.bucket.differ.schema ensureDynamicMemberExistsForObject:value key:key];
 }
 
 - (SPStorage *)threadSafeStorage {

--- a/Simperium/SPObject.h
+++ b/Simperium/SPObject.h
@@ -11,12 +11,11 @@
 
 @interface SPObject : NSObject<SPDiffable>
 
-// Note: Readonly for now!
-@property (nonatomic, strong, readonly) NSDictionary *dict;
 @property (nonatomic, strong) SPGhost *ghost;
 @property (nonatomic, copy) NSString *ghostData;
 @property (nonatomic, copy) NSString *simperiumKey;
-@property (nonatomic, copy) NSString *version;
+@property (nonatomic, copy, readonly) NSString *version;
+@property (nonatomic, copy, readonly) NSDictionary *dictionary;
 
 - (instancetype)initWithDictionary:(NSMutableDictionary *)dictionary;
 

--- a/Simperium/SPObject.h
+++ b/Simperium/SPObject.h
@@ -9,12 +9,10 @@
 #import <Foundation/Foundation.h>
 #import "SPDiffable.h"
 
-@interface SPObject : NSObject<SPDiffable> {
-    NSMutableDictionary *dict;
-    NSString *simperiumKey;
-}
+@interface SPObject : NSObject<SPDiffable>
 
-@property (nonatomic, strong) NSMutableDictionary *dict;
+// Note: Readonly for now!
+@property (nonatomic, strong, readonly) NSDictionary *dict;
 @property (nonatomic, strong) SPGhost *ghost;
 @property (nonatomic, copy) NSString *ghostData;
 @property (nonatomic, copy) NSString *simperiumKey;

--- a/Simperium/SPObject.m
+++ b/Simperium/SPObject.m
@@ -10,7 +10,14 @@
 #import "SPGhost.h"
 #import "NSMutableDictionary+Simperium.h"
 
+
+@interface SPObject ()
+@property (nonatomic, strong) NSMutableDictionary *mutableStorage;
+@end
+
+
 @implementation SPObject
+
 @synthesize dict;
 @synthesize ghost;
 @synthesize bucket;
@@ -18,19 +25,14 @@
 @synthesize version;
 
 - (instancetype)init {
-    self = [self initWithDictionary:[NSMutableDictionary dictionary]];
-    if (self) {
-    }
-    return self;
+    return [self initWithDictionary:[NSMutableDictionary dictionary]];
 }
 
 - (instancetype)initWithDictionary:(NSMutableDictionary *)dictionary {
     self = [super init];
     if (self) {
-        self.dict = dictionary;
-        [self.dict associateObject:self];
-        SPGhost *newGhost = [[SPGhost alloc] init];
-        self.ghost = newGhost;
+        self.mutableStorage = dictionary;
+        self.ghost = [SPGhost new];
     }
     return self;    
 }
@@ -53,7 +55,7 @@
 // These are needed to compose a dict
 - (void)simperiumSetValue:(id)value forKey:(NSString *)key {
     dispatch_barrier_async(dispatch_get_main_queue(), ^{
-        [dict setObject:value forKey:key];
+        [self.mutableStorage setObject:value forKey:key];
     });
 }
 
@@ -61,7 +63,7 @@
     __block id obj;
 
     dispatch_block_t block = ^{
-        obj = [dict objectForKey: key];
+        obj = [self.mutableStorage objectForKey: key];
     };
     
     // Note: For thread safety reasons, let's use the dictionary just from the main thread
@@ -76,7 +78,7 @@
 
 - (void)loadMemberData:(NSDictionary *)data {
     dispatch_barrier_async(dispatch_get_main_queue(), ^{
-        [dict setValuesForKeysWithDictionary:data];
+        [self.mutableStorage setValuesForKeysWithDictionary:data];
     });
 }
 
@@ -85,12 +87,11 @@
 }
 
 - (NSDictionary *)dictionary {
-    return dict;
+    return [self.mutableStorage copy];
 }
 
 - (id)object {
-    return dict;
+    return [self.mutableStorage copy];
 }
-
 
 @end

--- a/Simperium/SPObject.m
+++ b/Simperium/SPObject.m
@@ -45,10 +45,7 @@
 
 - (void)simperiumSetValue:(id)value forKey:(NSString *)key {
     [self.mutableStorage setObject:value forKey:key];
-
-    dispatch_barrier_async(dispatch_get_main_queue(), ^{
-        [self.bucket.schema addMemberForObject:value key:key];
-    });
+    [self.bucket.schema addMemberForObject:value key:key];
 }
 
 - (id)simperiumValueForKey:(NSString *)key {
@@ -57,10 +54,7 @@
 
 - (void)loadMemberData:(NSDictionary *)data {
     [self.mutableStorage setValuesForKeysWithDictionary:data];
-
-    dispatch_barrier_async(dispatch_get_main_queue(), ^{
-        [self ensureSchemaMembersAreAdded];
-    });
+    [self ensureSchemaMembersAreAdded];
 }
 
 - (void)ensureSchemaMembersAreAdded {

--- a/Simperium/SPObject.m
+++ b/Simperium/SPObject.m
@@ -58,8 +58,6 @@
 }
 
 - (void)ensureSchemaMembersAreAdded {
-    NSAssert([NSThread isMainThread], @"Please invoke this API from the main thread only");
-
     for (NSString *key in self.mutableStorage.allKeys) {
         id value = [self.mutableStorage objectForKey:key];
         if (value == nil) {

--- a/Simperium/SPObject.m
+++ b/Simperium/SPObject.m
@@ -17,7 +17,6 @@
 
 @implementation SPObject
 
-@synthesize dict;
 @synthesize ghost;
 @synthesize bucket;
 @synthesize ghostData;

--- a/Simperium/SPObject.m
+++ b/Simperium/SPObject.m
@@ -45,7 +45,7 @@
 
 - (void)simperiumSetValue:(id)value forKey:(NSString *)key {
     [self.mutableStorage setObject:value forKey:key];
-    [self.bucket.schema addMemberForObject:value key:key];
+    [self.bucket.schema ensureDynamicMemberExistsForObject:value key:key];
 }
 
 - (id)simperiumValueForKey:(NSString *)key {
@@ -66,7 +66,7 @@
             continue;
         }
 
-        [self.bucket.schema addMemberForObject:value key:key];
+        [self.bucket.schema ensureDynamicMemberExistsForObject:value key:key];
     }
 }
 

--- a/Simperium/SPObject.m
+++ b/Simperium/SPObject.m
@@ -8,7 +8,6 @@
 
 #import "SPObject.h"
 #import "SPGhost.h"
-#import "NSMutableDictionary+Simperium.h"
 
 
 @interface SPObject ()
@@ -35,16 +34,6 @@
         self.ghost = [SPGhost new];
     }
     return self;    
-}
-
-- (NSString *)simperiumKey {
-    return simperiumKey;
-}
-
-- (void)setSimperiumKey:(NSString *)key {
-    simperiumKey = [key copy];
-    
-    [self.dict associateSimperiumKey:simperiumKey];
 }
 
 // TODO: need to swizzle setObject:forKey: to inform Simperium that data has changed

--- a/Simperium/SPSchema.h
+++ b/Simperium/SPSchema.h
@@ -23,6 +23,6 @@
 - (instancetype)initWithBucketName:(NSString *)name data:(NSDictionary *)definition;
 - (SPMember *)memberForKey:(NSString *)memberName;
 - (void)setDefaults:(id<SPDiffable>)object;
-- (void)addMemberForObject:(id)object key:(NSString *)key;
+- (void)ensureDynamicMemberExistsForObject:(id)object key:(NSString *)key;
 
 @end

--- a/Simperium/SPSchema.m
+++ b/Simperium/SPSchema.m
@@ -76,7 +76,7 @@
     return self;
 }
 
-- (void)addMemberForObject:(id)object key:(NSString *)key {
+- (void)ensureDynamicMemberExistsForObject:(id)object key:(NSString *)key {
     if (!_dynamic) {
         return;
     }

--- a/Simperium/SPStorageProvider.h
+++ b/Simperium/SPStorageProvider.h
@@ -19,6 +19,7 @@
 // Properties
 @property (nonatomic, copy, readwrite) NSDictionary *metadata;
 @property (nonatomic, copy,  readonly) NSSet        *stashedObjects;
+@property (nonatomic, assign, readonly) BOOL        isEphemeral;
 
 // Persistance
 - (BOOL)save;

--- a/Simperium/SPThreadsafeMutableDictionary.h
+++ b/Simperium/SPThreadsafeMutableDictionary.h
@@ -1,0 +1,27 @@
+//
+//  SPThreadsafeMutableDictionary.h
+//  Simperium
+//
+//  Created by Lantean on 1/14/21.
+//  Copyright © 2021 Simperium. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+
+#pragma mark - SPThreadsafeMutableDictionary
+
+@interface SPThreadsafeMutableDictionary : NSObject
+
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary;
+
+- (NSArray<NSString *> *)allKeys;
+
+- (void)setObject:(id)object forKey:(NSString *)key;
+- (void)setValuesForKeysWithDictionary:(NSDictionary<NSString *, id> *)keyedValues;
+- (id)objectForKey:(NSString *)key;
+- (void)removeObjectForKey:(NSString *)key;
+
+- (NSDictionary *)copyInternalStorage;
+
+@end

--- a/Simperium/SPThreadsafeMutableDictionary.m
+++ b/Simperium/SPThreadsafeMutableDictionary.m
@@ -52,6 +52,10 @@
 
 - (void)setObject:(id)object forKey:(NSString *)key {
     dispatch_sync(self.queue, ^{
+        if (!object) {
+            [self.contents removeObjectForKey:key];
+            return;
+        }
         [self.contents setObject:object forKey:key];
     });
 }

--- a/Simperium/SPThreadsafeMutableDictionary.m
+++ b/Simperium/SPThreadsafeMutableDictionary.m
@@ -26,7 +26,7 @@
     self = [super init];
     if (self) {
         self.contents = [NSMutableDictionary dictionary];
-        self.queue = dispatch_queue_create("com.simperium.SPThreadsafeMutableSet", NULL);
+        self.queue = dispatch_queue_create("com.simperium.SPThreadsafeMutableDictionary", NULL);
     }
 
     return self;

--- a/Simperium/SPThreadsafeMutableDictionary.m
+++ b/Simperium/SPThreadsafeMutableDictionary.m
@@ -1,0 +1,87 @@
+//
+//  SPThreadsafeMutableDictionary.m
+//  Simperium
+//
+//  Created by Lantean on 1/14/21.
+//  Copyright © 2021 Simperium. All rights reserved.
+//
+
+#import "SPThreadsafeMutableDictionary.h"
+
+
+
+#pragma mark - Private
+
+@interface SPThreadsafeMutableDictionary ()
+@property (nonatomic, strong) NSMutableDictionary   *contents;
+@property (nonatomic, strong) dispatch_queue_t      queue;
+@end
+
+
+#pragma mark - SPThreadsafeMutableDictionary
+
+@implementation SPThreadsafeMutableDictionary
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.contents = [NSMutableDictionary dictionary];
+        self.queue = dispatch_queue_create("com.simperium.SPThreadsafeMutableSet", NULL);
+    }
+
+    return self;
+}
+
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary {
+    self = [self init];
+    if (self && dictionary != nil) {
+        [self.contents addEntriesFromDictionary:dictionary];
+    }
+
+    return self;
+}
+
+- (NSArray<NSString *> *)allKeys {
+    __block NSArray *allKeys = nil;
+    dispatch_sync(self.queue, ^{
+        allKeys = self.contents.allKeys;
+    });
+
+    return allKeys;
+}
+
+- (void)setObject:(id)object forKey:(NSString *)key {
+    dispatch_sync(self.queue, ^{
+        [self.contents setObject:object forKey:key];
+    });
+}
+
+- (void)setValuesForKeysWithDictionary:(NSDictionary<NSString *, id> *)keyedValues {
+    dispatch_sync(self.queue, ^{
+        [self.contents setValuesForKeysWithDictionary:keyedValues];
+    });
+}
+
+- (id)objectForKey:(NSString *)key {
+    __block id object = nil;
+    dispatch_sync(self.queue, ^{
+        object = [self.contents objectForKey:key];
+    });
+    return object;
+}
+
+- (void)removeObjectForKey:(NSString *)key {
+    dispatch_sync(self.queue, ^{
+        [self.contents removeObjectForKey:key];
+    });
+}
+
+- (NSDictionary *)copyInternalStorage {
+    __block id output = nil;
+    dispatch_sync(self.queue, ^{
+        output = [self.contents copy];
+    });
+    return output;
+}
+
+@end

--- a/Simperium/Simperium.m
+++ b/Simperium/Simperium.m
@@ -673,6 +673,14 @@ static SPLogLevels logLevel                     = SPLogLevelsInfo;
 #pragma mark Properties
 #pragma mark ====================================================================================
 
+- (SPJSONStorage *)JSONStorage {
+    if (!_JSONStorage) {
+        _JSONStorage = [[SPJSONStorage alloc] initWithDelegate:self];
+    }
+
+    return _JSONStorage;
+}
+
 - (NSManagedObjectContext *)managedObjectContext {
     return self.coreDataStorage.mainManagedObjectContext;
 }

--- a/SimperiumTests/MockStorage.m
+++ b/SimperiumTests/MockStorage.m
@@ -35,6 +35,10 @@ static NSInteger const SPWorkersDone = 0;
     return self;
 }
 
+- (BOOL)isEphemeral {
+    return YES;
+}
+
 - (BOOL)save {
     // No-Op
     return YES;

--- a/SimperiumTests/SPThreadsafeMutableDictionaryTests.m
+++ b/SimperiumTests/SPThreadsafeMutableDictionaryTests.m
@@ -1,0 +1,83 @@
+//
+//  SPThreadsafeMutableDictionaryTests.m
+//  UnitTests
+//
+//  Created by Lantean on 1/14/21.
+//  Copyright © 2021 Simperium. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "SPThreadsafeMutableDictionary.h"
+#import "XCTestCase+Simperium.h"
+
+
+#pragma mark - Constants
+
+static NSUInteger const SPIterations                = 10000;
+static NSUInteger const SPConcurrentWorkers         = 100;
+static NSTimeInterval const SPExpectationTimeout    = 60.0;
+
+
+#pragma mark - SPThreadsafeMutableDictionaryTests
+
+@interface SPThreadsafeMutableDictionaryTests : XCTestCase
+
+@end
+
+@implementation SPThreadsafeMutableDictionaryTests
+
+- (void)testMultipleConcurrentWorkersCanManipulateThreadsafeDictionaryWithoutTriggeringCrashes {
+
+    SPThreadsafeMutableDictionary *dictionary = [SPThreadsafeMutableDictionary new];
+    dispatch_group_t group = dispatch_group_create();
+
+    // Launch concurrent workers
+    for (NSInteger i = 0; ++i <= SPConcurrentWorkers; ) {
+        dispatch_queue_t queue = dispatch_queue_create("com.simperium.SPThreadsafeMutableDictionaryTests", NULL);
+
+        dispatch_group_enter(group);
+        dispatch_async(queue, ^{
+
+            for (NSInteger i = 0; ++i <= SPIterations; ) {
+                NSString *key = [NSString stringWithFormat:@"%ld", (long)i];
+                [dictionary setObject:@(i) forKey:key];
+            }
+            dispatch_group_leave(group);
+        });
+    }
+
+    // Remember: Since it's a set, we should have 'SPSetIterations' objects
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Expectation"];
+
+    dispatch_group_notify(group, dispatch_get_main_queue(), ^{
+
+        for (NSInteger i = 0; ++i <= SPIterations; ) {
+            NSString *key = [NSString stringWithFormat:@"%ld", (long)i];
+            NSNumber *value = [dictionary objectForKey:key];
+
+            XCTAssertEqual(key, value.description);
+
+            [dictionary removeObjectForKey:key];
+            XCTAssertFalse([dictionary objectForKey:key], @"Delete Failed");
+        }
+
+        [expectation fulfill];
+    });
+
+    [self waitForExpectationsWithTimeout:SPExpectationTimeout handler:^(NSError *error) {
+        XCTAssertNil(error, @"Expectations Timeout");
+    }];
+}
+
+- (void)testCopyInternalStorageEffectivelyCopiesThePrivateDictionary {
+    SPThreadsafeMutableDictionary *dictionary = [SPThreadsafeMutableDictionary new];
+    for (NSInteger i = -1; ++i < SPIterations; ) {
+        NSString *key = [NSString stringWithFormat:@"%ld", (long)i];
+        [dictionary setObject:@(i) forKey:key];
+    }
+
+    NSDictionary *internalStorageCopy = [dictionary copyInternalStorage];
+    XCTAssertEqual(internalStorageCopy.count, SPIterations);
+}
+
+@end


### PR DESCRIPTION
### Description:
In this PR we're enabling JSON Storage support, and fixing few bugs along the way.
At this stage, our JSON Storage layer doesn't have change tracking support. We'll revisit this in a future iteration.

### Details:
- Implements **SPThreadsafeMutableDictionary**
- Updates **SPObject** so that it relies on the new Threadsafe Mutable Dictionary component
- Dynamic Buckets **no longer** persist the lastSeenChange string
- **SPDiffable:** Replaced methods in favor of properties
- **SPJSONStorage:** Dropped Swizzling

### Testing:
- [ ] Verify the Unit Tests are green!
- [ ] Please refer to [this Simplenote iOS PR](https://github.com/Automattic/simplenote-ios/pull/1091) for futher testing steps.
