### PR TITLE
SPAuthenticationTextField: NSCoder support

### DIFF
--- a/Simperium-OSX/SPAuthenticationTextField.h
+++ b/Simperium-OSX/SPAuthenticationTextField.h
@@ -21,8 +21,3 @@
 - (void)setEnabled:(BOOL)enabled;
 
 @end
-
-
-@interface SPAuthenticationSecureTextField : SPAuthenticationTextField
-
-@end

--- a/Simperium-OSX/SPAuthenticationTextField.h
+++ b/Simperium-OSX/SPAuthenticationTextField.h
@@ -13,10 +13,16 @@
 @property (assign) id delegate;
 @property (strong) NSTextField *textField;
 
-- (id)initWithFrame:(NSRect)frame secure:(BOOL)secure;
+- (instancetype)initWithFrame:(NSRect)frame secure:(BOOL)secure;
+
 - (void)setPlaceholderString:(NSString *)string;
 - (NSString *)stringValue;
 - (void)setStringValue:(NSString *)string;
 - (void)setEnabled:(BOOL)enabled;
+
+@end
+
+
+@interface SPAuthenticationSecureTextField : SPAuthenticationTextField
 
 @end

--- a/Simperium-OSX/SPAuthenticationTextField.m
+++ b/Simperium-OSX/SPAuthenticationTextField.m
@@ -16,7 +16,6 @@
 #pragma mark ====================================================================================
 
 static NSString* SPTextFieldDidBecomeFirstResponder = @"SPTextFieldDidBecomeFirstResponder";
-static NSString *SPTextFieldSecureKey = @"secure";
 
 
 #pragma mark ====================================================================================
@@ -56,9 +55,7 @@ static NSString *SPTextFieldSecureKey = @"secure";
 
 
 
-#pragma mark ====================================================================================
-#pragma mark SPAuthenticationTextField
-#pragma mark ====================================================================================
+#pragma mark - SPAuthenticationTextField
 
 @interface SPAuthenticationTextField()
 @property (nonatomic, assign) BOOL isWindowFistResponder;
@@ -79,12 +76,11 @@ static NSString *SPTextFieldSecureKey = @"secure";
     return self;
 }
 
-
 - (instancetype)initWithCoder:(NSCoder *)coder {
     self = [super initWithCoder:coder];
     if (self) {
-        BOOL secure = [[self valueForKey:SPTextFieldSecureKey] boolValue];
-        [self setupInterface:secure];
+        // TODO: Should probably read the mode from NSCoder. Falling back to unsecured by default
+        [self setupInterface:NO];
     }
 
     return self;
@@ -170,6 +166,23 @@ static NSString *SPTextFieldSecureKey = @"secure";
 - (void)handleTextFieldDidFinishEditing:(NSNotification *)note {
     self.isWindowFistResponder = NO;
     [self setNeedsDisplay:YES];
+}
+
+@end
+
+
+
+#pragma mark - SPAuthenticationSecureTextField
+
+@implementation SPAuthenticationSecureTextField
+
+- (instancetype)initWithCoder:(NSCoder *)coder {
+    self = [super initWithCoder:coder];
+    if (self) {
+        [super setupInterface:YES];
+    }
+
+    return self;
 }
 
 @end

--- a/Simperium-OSX/SPAuthenticationTextField.m
+++ b/Simperium-OSX/SPAuthenticationTextField.m
@@ -16,6 +16,7 @@
 #pragma mark ====================================================================================
 
 static NSString* SPTextFieldDidBecomeFirstResponder = @"SPTextFieldDidBecomeFirstResponder";
+static NSString *SPTextFieldSecureKey = @"secure";
 
 
 #pragma mark ====================================================================================
@@ -72,26 +73,28 @@ static NSString* SPTextFieldDidBecomeFirstResponder = @"SPTextFieldDidBecomeFirs
 - (instancetype)initWithFrame:(NSRect)frame secure:(BOOL)secure {
     self = [super initWithFrame:frame];
     if (self) {
-        [self setupInterface];
+        [self setupInterface:secure];
     }
 
-    return self
+    return self;
 }
 
 
 - (instancetype)initWithCoder:(NSCoder *)coder {
     self = [super initWithCoder:coder];
     if (self) {
-        [self setupInterface];
+        BOOL secure = [[self valueForKey:SPTextFieldSecureKey] boolValue];
+        [self setupInterface:secure];
     }
 
     return self;
 }
 
-- (void)setupInterface {
+- (void)setupInterface:(BOOL)secure {
     // Center the textField vertically
-    int paddingX = 10;
-    int fontSize = 20;
+    NSRect frame = self.frame;
+    CGFloat paddingX = 10;
+    CGFloat fontSize = 20;
     CGFloat fieldHeight = [[SPAuthenticationConfiguration sharedInstance] regularFontHeightForSize:fontSize];
     CGFloat fieldY = (self.frame.size.height - fieldHeight) / 2;
     CGRect textFrame = NSMakeRect(paddingX, fieldY, frame.size.width-paddingX*2, fieldHeight);

--- a/Simperium-OSX/SPAuthenticationTextField.m
+++ b/Simperium-OSX/SPAuthenticationTextField.m
@@ -72,32 +72,46 @@ static NSString* SPTextFieldDidBecomeFirstResponder = @"SPTextFieldDidBecomeFirs
 - (instancetype)initWithFrame:(NSRect)frame secure:(BOOL)secure {
     self = [super initWithFrame:frame];
     if (self) {
-        // Center the textField vertically
-        int paddingX = 10;
-        int fontSize = 20;
-        CGFloat fieldHeight = [[SPAuthenticationConfiguration sharedInstance] regularFontHeightForSize:fontSize];
-        CGFloat fieldY = (self.frame.size.height - fieldHeight) / 2;
-        CGRect textFrame = NSMakeRect(paddingX, fieldY, frame.size.width-paddingX*2, fieldHeight);
-
-        Class textFieldClass = secure ? [SPSecureTextField class] : [SPTextField class];
-        _textField = [[textFieldClass alloc] initWithFrame:textFrame];
-        NSFont *font = [NSFont fontWithName:[SPAuthenticationConfiguration sharedInstance].regularFontName size:fontSize];
-        [_textField setFont:font];
-        [_textField setTextColor:[NSColor colorWithCalibratedWhite:0.1 alpha:1.0]];
-        [_textField setDrawsBackground:NO];
-        [_textField setBezeled:NO];
-        [_textField setBordered:NO];
-        [_textField setFocusRingType:NSFocusRingTypeNone];
-        [[_textField cell] setWraps:NO];
-        [[_textField cell] setScrollable:YES];
-        [self addSubview:_textField];
-        
-        NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-        [nc addObserver:self selector:@selector(handleTextFieldDidBeginEditing:) name:SPTextFieldDidBecomeFirstResponder object:_textField];
-        [nc addObserver:self selector:@selector(handleTextFieldDidFinishEditing:) name:NSControlTextDidEndEditingNotification object:_textField];
+        [self setupInterface];
     }
-    
+
+    return self
+}
+
+
+- (instancetype)initWithCoder:(NSCoder *)coder {
+    self = [super initWithCoder:coder];
+    if (self) {
+        [self setupInterface];
+    }
+
     return self;
+}
+
+- (void)setupInterface {
+    // Center the textField vertically
+    int paddingX = 10;
+    int fontSize = 20;
+    CGFloat fieldHeight = [[SPAuthenticationConfiguration sharedInstance] regularFontHeightForSize:fontSize];
+    CGFloat fieldY = (self.frame.size.height - fieldHeight) / 2;
+    CGRect textFrame = NSMakeRect(paddingX, fieldY, frame.size.width-paddingX*2, fieldHeight);
+
+    Class textFieldClass = secure ? [SPSecureTextField class] : [SPTextField class];
+    _textField = [[textFieldClass alloc] initWithFrame:textFrame];
+    NSFont *font = [NSFont fontWithName:[SPAuthenticationConfiguration sharedInstance].regularFontName size:fontSize];
+    [_textField setFont:font];
+    [_textField setTextColor:[NSColor colorWithCalibratedWhite:0.1 alpha:1.0]];
+    [_textField setDrawsBackground:NO];
+    [_textField setBezeled:NO];
+    [_textField setBordered:NO];
+    [_textField setFocusRingType:NSFocusRingTypeNone];
+    [[_textField cell] setWraps:NO];
+    [[_textField cell] setScrollable:YES];
+    [self addSubview:_textField];
+
+    NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+    [nc addObserver:self selector:@selector(handleTextFieldDidBeginEditing:) name:SPTextFieldDidBecomeFirstResponder object:_textField];
+    [nc addObserver:self selector:@selector(handleTextFieldDidFinishEditing:) name:NSControlTextDidEndEditingNotification object:_textField];
 }
 
 - (void)setStringValue:(NSString *)string {

--- a/Simperium-OSX/SPAuthenticationTextField.m
+++ b/Simperium-OSX/SPAuthenticationTextField.m
@@ -59,6 +59,7 @@ static NSString* SPTextFieldDidBecomeFirstResponder = @"SPTextFieldDidBecomeFirs
 
 @interface SPAuthenticationTextField()
 @property (nonatomic, assign) BOOL isWindowFistResponder;
+@property (nonatomic, assign) BOOL secure;
 @end
 
 @implementation SPAuthenticationTextField
@@ -76,14 +77,9 @@ static NSString* SPTextFieldDidBecomeFirstResponder = @"SPTextFieldDidBecomeFirs
     return self;
 }
 
-- (instancetype)initWithCoder:(NSCoder *)coder {
-    self = [super initWithCoder:coder];
-    if (self) {
-        // TODO: Should probably read the mode from NSCoder. Falling back to unsecured by default
-        [self setupInterface:NO];
-    }
-
-    return self;
+- (void)awakeFromNib {
+    [super awakeFromNib];
+    [self setupInterface:self.secure];
 }
 
 - (void)setupInterface:(BOOL)secure {
@@ -141,11 +137,11 @@ static NSString* SPTextFieldDidBecomeFirstResponder = @"SPTextFieldDidBecomeFirs
 - (void)drawRect:(NSRect)dirtyRect {
     NSBezierPath *betterBounds = [NSBezierPath bezierPathWithRect:self.bounds];
     [betterBounds addClip];
-    
+
     if (self.isWindowFistResponder) {
         [[NSColor colorWithCalibratedWhite:0.9 alpha:1.0] setFill];
         [betterBounds fill];
-        
+
     } else {
         [[NSColor colorWithCalibratedWhite:250.f/255.f alpha:1.0] setFill];
         [betterBounds fill];
@@ -166,23 +162,6 @@ static NSString* SPTextFieldDidBecomeFirstResponder = @"SPTextFieldDidBecomeFirs
 - (void)handleTextFieldDidFinishEditing:(NSNotification *)note {
     self.isWindowFistResponder = NO;
     [self setNeedsDisplay:YES];
-}
-
-@end
-
-
-
-#pragma mark - SPAuthenticationSecureTextField
-
-@implementation SPAuthenticationSecureTextField
-
-- (instancetype)initWithCoder:(NSCoder *)coder {
-    self = [super initWithCoder:coder];
-    if (self) {
-        [super setupInterface:YES];
-    }
-
-    return self;
 }
 
 @end


### PR DESCRIPTION
### Details:
In this PR we're updating **SPAuthenticationTextField** so that NSCoder initialization is also supported.

cc @eshurakov (Thank you!!)