### PR TITLE
Preventing AuthUI Repositioning 

### DIFF
--- a/Simperium/Simperium.m
+++ b/Simperium/Simperium.m
@@ -911,9 +911,15 @@ static SPLogLevels logLevel                     = SPLogLevelsInfo;
     }
     
     // Hide the main window and show the auth window instead
-    [self.window setIsVisible:NO];    
-    [[self.authenticationWindowController window] center];
-    [[self.authenticationWindowController window] makeKeyAndOrderFront:self];
+    [self.window setIsVisible:NO];
+
+    // Center the AuthWindow *only* when it wasn't previously onscreen (only after alloc!)
+    NSWindow *authWindow = self.authenticationWindowController.window;
+    if (!authWindow.isVisible) {
+        [authWindow center];
+    }
+
+    [authWindow makeKeyAndOrderFront:self];
 #endif
 }
 


### PR DESCRIPTION
### Details:
In this PR we're preventing the Auth UI from being repositioned, whenever it was already visible.

cc @eshurakov 

### Testing
Please refer to [this Simplenote PR](https://github.com/Automattic/simplenote-macos/pull/890) and verify the **Test: Auth Repositioning** scenarios are good!
