### PR TITLE
Fixing AuthTextField UI Glitch

### DIFF
--- a/Simperium-OSX/SPAuthenticationTextField.h
+++ b/Simperium-OSX/SPAuthenticationTextField.h
@@ -14,7 +14,7 @@
 @property (nonatomic,   weak, readwrite) id<NSTextFieldDelegate>    delegate;
 @property (nonatomic,   copy, readwrite) NSString                   *stringValue;
 @property (nonatomic,   copy, readwrite) NSString                   *placeholderString;
-@property (nonatomic, assign, readwrite) BOOL                       enabled;
+@property (nonatomic, assign, readwrite) BOOL                       isEnabled;
 
 - (instancetype)initWithFrame:(NSRect)frame secure:(BOOL)secure;
 

--- a/Simperium-OSX/SPAuthenticationTextField.h
+++ b/Simperium-OSX/SPAuthenticationTextField.h
@@ -14,7 +14,7 @@
 @property (nonatomic,   weak, readwrite) id<NSTextFieldDelegate>    delegate;
 @property (nonatomic,   copy, readwrite) NSString                   *stringValue;
 @property (nonatomic,   copy, readwrite) NSString                   *placeholderString;
-@property (nonatomic, assign, readwrite) BOOL                       isEnabled;
+@property (nonatomic, assign, readwrite, getter=isEnabled) BOOL     enabled;
 
 - (instancetype)initWithFrame:(NSRect)frame secure:(BOOL)secure;
 

--- a/Simperium-OSX/SPAuthenticationTextField.h
+++ b/Simperium-OSX/SPAuthenticationTextField.h
@@ -10,14 +10,12 @@
 
 @interface SPAuthenticationTextField : NSView
 
-@property (assign) id delegate;
-@property (strong) NSTextField *textField;
+@property (nonatomic,  strong, readonly) NSTextField                *textField;
+@property (nonatomic,   weak, readwrite) id<NSTextFieldDelegate>    delegate;
+@property (nonatomic,   copy, readwrite) NSString                   *stringValue;
+@property (nonatomic,   copy, readwrite) NSString                   *placeholderString;
+@property (nonatomic, assign, readwrite) BOOL                       enabled;
 
 - (instancetype)initWithFrame:(NSRect)frame secure:(BOOL)secure;
-
-- (void)setPlaceholderString:(NSString *)string;
-- (NSString *)stringValue;
-- (void)setStringValue:(NSString *)string;
-- (void)setEnabled:(BOOL)enabled;
 
 @end

--- a/Simperium-OSX/SPAuthenticationTextField.m
+++ b/Simperium-OSX/SPAuthenticationTextField.m
@@ -11,50 +11,6 @@
 
 
 
-#pragma mark ====================================================================================
-#pragma mark Constants
-#pragma mark ====================================================================================
-
-static NSString* SPTextFieldDidBecomeFirstResponder = @"SPTextFieldDidBecomeFirstResponder";
-
-
-#pragma mark ====================================================================================
-#pragma mark Private Helper: SPTextField
-#pragma mark ====================================================================================
-
-@interface SPTextField : NSTextField
-
-@end
-
-@implementation SPTextField
-
-- (BOOL)becomeFirstResponder {
-    [[NSNotificationCenter defaultCenter] postNotificationName:SPTextFieldDidBecomeFirstResponder object:self];
-    return [super becomeFirstResponder];
-}
-
-@end
-
-
-
-#pragma mark ====================================================================================
-#pragma mark Private Helper: SPSecureTextField
-#pragma mark ====================================================================================
-
-@interface SPSecureTextField : NSSecureTextField
-@end
-
-@implementation SPSecureTextField
-
-- (BOOL)becomeFirstResponder {
-    [[NSNotificationCenter defaultCenter] postNotificationName:SPTextFieldDidBecomeFirstResponder object:self];
-    return [super becomeFirstResponder];
-}
-
-@end
-
-
-
 #pragma mark - SPAuthenticationTextField
 
 @interface SPAuthenticationTextField()
@@ -91,7 +47,7 @@ static NSString* SPTextFieldDidBecomeFirstResponder = @"SPTextFieldDidBecomeFirs
     CGFloat fieldY = (self.frame.size.height - fieldHeight) / 2;
     CGRect textFrame = NSMakeRect(paddingX, fieldY, frame.size.width-paddingX*2, fieldHeight);
 
-    Class textFieldClass = secure ? [SPSecureTextField class] : [SPTextField class];
+    Class textFieldClass = secure ? [NSSecureTextField class] : [NSTextField class];
     _textField = [[textFieldClass alloc] initWithFrame:textFrame];
     NSFont *font = [NSFont fontWithName:[SPAuthenticationConfiguration sharedInstance].regularFontName size:fontSize];
     [_textField setFont:font];
@@ -105,8 +61,8 @@ static NSString* SPTextFieldDidBecomeFirstResponder = @"SPTextFieldDidBecomeFirs
     [self addSubview:_textField];
 
     NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-    [nc addObserver:self selector:@selector(handleTextFieldDidBeginEditing:) name:SPTextFieldDidBecomeFirstResponder object:_textField];
-    [nc addObserver:self selector:@selector(handleTextFieldDidFinishEditing:) name:NSControlTextDidEndEditingNotification object:_textField];
+    [nc addObserver:self selector:@selector(handleTextFieldDidBeginEditing:) name:NSTextDidBeginEditingNotification object:nil];
+    [nc addObserver:self selector:@selector(handleTextFieldDidFinishEditing:) name:NSTextDidEndEditingNotification object:nil];
 }
 
 - (void)setStringValue:(NSString *)string {

--- a/Simperium-OSX/SPAuthenticationTextField.m
+++ b/Simperium-OSX/SPAuthenticationTextField.m
@@ -39,7 +39,6 @@
 }
 
 - (void)setupInterface:(BOOL)secure {
-    // Center the textField vertically
     NSRect frame = self.frame;
     CGFloat paddingX = 10;
     CGFloat fontSize = 20;
@@ -94,7 +93,7 @@
     NSBezierPath *betterBounds = [NSBezierPath bezierPathWithRect:self.bounds];
     [betterBounds addClip];
 
-    if (self.isWindowFistResponder) {
+    if (self.sp_isFirstResponder) {
         [[NSColor colorWithCalibratedWhite:0.9 alpha:1.0] setFill];
         [betterBounds fill];
 
@@ -107,16 +106,24 @@
     }
 }
 
+- (BOOL)sp_isFirstResponder {
+    NSResponder *responder = [self.window firstResponder];
+    if (![responder isKindOfClass:[NSText class]]) {
+        return responder == self.textField;
+    }
+
+    NSText *fieldEditor = (NSText *)responder;
+    return fieldEditor.delegate == (id<NSTextDelegate>)self.textField;
+}
+
 
 #pragma mark - Notification Helpers
 
 - (void)handleTextFieldDidBeginEditing:(NSNotification *)note {
-    self.isWindowFistResponder = YES;
     [self setNeedsDisplay:YES];
 }
 
 - (void)handleTextFieldDidFinishEditing:(NSNotification *)note {
-    self.isWindowFistResponder = NO;
     [self setNeedsDisplay:YES];
 }
 

--- a/Simperium-OSX/SPAuthenticationTextField.m
+++ b/Simperium-OSX/SPAuthenticationTextField.m
@@ -14,7 +14,6 @@
 #pragma mark - SPAuthenticationTextField
 
 @interface SPAuthenticationTextField()
-@property (nonatomic, assign) BOOL isWindowFistResponder;
 @property (nonatomic, assign) BOOL secure;
 @end
 
@@ -76,6 +75,10 @@
     [[_textField cell] setPlaceholderString:string];
 }
 
+- (NSString *)placeholderString {
+    return [[_textField cell] placeholderString];
+}
+
 - (void)setDelegate:(id)delegate {
     _textField.delegate = delegate;
 }
@@ -87,6 +90,10 @@
 - (void)setEnabled:(BOOL)enabled {
     [_textField setEnabled:enabled];
     [_textField setEditable:enabled];
+}
+
+- (BOOL)isEnabled {
+    return _textField.enabled;
 }
 
 - (void)drawRect:(NSRect)dirtyRect {


### PR DESCRIPTION
### Details:
In this PR we're updating the mechanism used by **SPAuthenticationTextField** to determine its first responder state.
Previous mechanism failed in specific scenarios, causing the "Active State" to fall out of sync.

### Testing
Please refer to [this Simplenote PR](https://github.com/Automattic/simplenote-macos/pull/900) for testing steps.
