### PR TITLE
Support SwiftPM distribution via XCFramework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ profile
 *.moved-aside
 DerivedData
 .idea/
+
+# XCFramework build
+.build

--- a/Headers/Simperium_OSX.h
+++ b/Headers/Simperium_OSX.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Simperium. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
 //! Project version number for Simperium-iOS.
 FOUNDATION_EXPORT double Simperium_iOSVersionNumber;
@@ -19,10 +19,13 @@ FOUNDATION_EXPORT const unsigned char Simperium_iOSVersionString[];
 #pragma mark Public Headers
 #pragma mark ====================================================================================
 
+#import <Simperium/NSDate+Simperium.h>
+
 #import <Simperium/Simperium.h>
 #import <Simperium/SPAuthenticationInterface.h>
-#import <Simperium/SPAuthenticationViewController.h>
 #import <Simperium/SPAuthenticationConfiguration.h>
+#import <Simperium/SPAuthenticationValidator.h>
+#import <Simperium/SPAuthenticationTextField.h>
 #import <Simperium/SPAuthenticator.h>
 #import <Simperium/SPBucket.h>
 #import <Simperium/SPCoreDataExporter.h>
@@ -32,3 +35,6 @@ FOUNDATION_EXPORT const unsigned char Simperium_iOSVersionString[];
 #import <Simperium/SPNetworkInterface.h>
 #import <Simperium/SPStorageProvider.h>
 #import <Simperium/SPUser.h>
+
+#import <Simperium/SPKeychain.h>
+#import <Simperium/SPKeychainQuery.h>

--- a/Headers/Simperium_iOS.h
+++ b/Headers/Simperium_iOS.h
@@ -32,3 +32,6 @@ FOUNDATION_EXPORT const unsigned char Simperium_OSXVersionString[];
 #import <Simperium/SPNetworkInterface.h>
 #import <Simperium/SPStorageProvider.h>
 #import <Simperium/SPUser.h>
+
+#import <Simperium/SPKeychain.h>
+#import <Simperium/SPKeychainQuery.h>

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ $(XCFRAMEWORKS_DIR)/$(LIB_NAME).xcframework: archive_all
 $(XCFRAMEWORKS_DIR)/$(LIB_NAME).xcframework.zip: $(XCFRAMEWORKS_DIR)/$(LIB_NAME).xcframework
 	@mkdir -p $(XCFRAMEWORKS_DIR)
 	codesign --timestamp -s $(CODE_SIGNING_IDENTITY) $<
-	zip -r $@ $<
+	ditto -c -k --keepParent $< $@
 	@echo "Checksum for $(LIB_NAME).xcframework.zip:"
 	@swift package compute-checksum $@
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+LIB_NAME := Simperium
+BUILD_DIR := .build/xcarchives
+FRAMEWORK_NAME := $(LIB_NAME).framework
+XCFRAMEWORKS_DIR := .build/xcframeworks
+
+IOS_SCHEME := $(LIB_NAME)
+MACOS_SCHEME := $(LIB_NAME)-OSX
+
+define BUILD_XCFRAMEWORK
+build_xcframework_$(1): $(XCFRAMEWORKS_DIR)/$(LIB_NAME)-$(1).xcframework
+
+$(BUILD_DIR)/$(1).xcarchive:
+	xcodebuild archive \
+		-scheme "Simperium $(if $(filter ios,$(1)),iOS,OSX)" \
+		-destination "generic/platform=$(if $(filter ios,$(1)),iOS,macOS)" \
+		-archivePath $$@ \
+		SKIP_INSTALL=NO \
+		BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+
+$(XCFRAMEWORKS_DIR)/$(LIB_NAME)-$(1).xcframework: $(BUILD_DIR)/$(1).xcarchive
+	@mkdir -p $(XCFRAMEWORKS_DIR)
+	xcodebuild -create-xcframework \
+		-framework $(BUILD_DIR)/$(1).xcarchive/Products/Library/Frameworks/$(FRAMEWORK_NAME) \
+		-output $$@
+endef
+
+$(eval $(call BUILD_XCFRAMEWORK,ios))
+$(eval $(call BUILD_XCFRAMEWORK,macos))
+
+build_all: build_xcframework_ios build_xcframework_macos

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,14 @@ MACOS_SCHEME := $(LIB_NAME)-OSX
 define BUILD_XCFRAMEWORK
 build_xcframework_$(1): $(XCFRAMEWORKS_DIR)/$(LIB_NAME)-$(1).xcframework.zip
 
+$(BUILD_DIR)/simulator.xcarchive:
+	xcodebuild archive \
+		-scheme "Simperium iOS" \
+		-destination "generic/platform=iOS Simulator" \
+		-archivePath $$@ \
+		SKIP_INSTALL=NO \
+		BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+
 $(BUILD_DIR)/$(1).xcarchive:
 	xcodebuild archive \
 		-scheme "Simperium $(if $(filter ios,$(1)),iOS,OSX)" \
@@ -17,10 +25,26 @@ $(BUILD_DIR)/$(1).xcarchive:
 		SKIP_INSTALL=NO \
 		BUILD_LIBRARY_FOR_DISTRIBUTION=YES
 
+$(BUILD_DIR)/ios_all.xcarchive: $(BUILD_DIR)/ios.xcarchive $(BUILD_DIR)/simulator.xcarchive
+	@touch $$@
+
 $(XCFRAMEWORKS_DIR)/$(LIB_NAME)-$(1).xcframework: $(BUILD_DIR)/$(1).xcarchive
 	@mkdir -p $(XCFRAMEWORKS_DIR)
 	xcodebuild -create-xcframework \
 		-framework $(BUILD_DIR)/$(1).xcarchive/Products/Library/Frameworks/$(FRAMEWORK_NAME) \
+		-output $$@
+
+$(XCFRAMEWORKS_DIR)/$(LIB_NAME)-ios.xcframework: $(BUILD_DIR)/ios_all.xcarchive
+	@mkdir -p $(XCFRAMEWORKS_DIR)
+	xcodebuild -create-xcframework \
+		-framework $(BUILD_DIR)/ios.xcarchive/Products/Library/Frameworks/$(FRAMEWORK_NAME) \
+		-framework $(BUILD_DIR)/simulator.xcarchive/Products/Library/Frameworks/$(FRAMEWORK_NAME) \
+		-output $$@
+
+$(XCFRAMEWORKS_DIR)/$(LIB_NAME)-macos.xcframework: $(BUILD_DIR)/macos.xcarchive
+	@mkdir -p $(XCFRAMEWORKS_DIR)
+	xcodebuild -create-xcframework \
+		-framework $(BUILD_DIR)/macos.xcarchive/Products/Library/Frameworks/$(FRAMEWORK_NAME) \
 		-output $$@
 
 $(XCFRAMEWORKS_DIR)/$(LIB_NAME)-$(1).xcframework.zip: $(XCFRAMEWORKS_DIR)/$(LIB_NAME)-$(1).xcframework

--- a/Makefile
+++ b/Makefile
@@ -1,58 +1,63 @@
+# See:
+#
+# - https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle
+# - https://developer.apple.com/documentation/xcode/distributing-binary-frameworks-as-swift-packages
+
 LIB_NAME := Simperium
 BUILD_DIR := .build/xcarchives
 FRAMEWORK_NAME := $(LIB_NAME).framework
 XCFRAMEWORKS_DIR := .build/xcframeworks
+CODE_SIGNING_IDENTITY ?= "Apple Distribution: Automattic, Inc. (PZYM8XX95Q)"
 
 IOS_SCHEME := $(LIB_NAME)
 MACOS_SCHEME := $(LIB_NAME)-OSX
 
-define BUILD_XCFRAMEWORK
-build_xcframework_$(1): $(XCFRAMEWORKS_DIR)/$(LIB_NAME)-$(1).xcframework.zip
+.PHONY: all clean
+all: create_xcframework
 
-$(BUILD_DIR)/simulator.xcarchive:
+clean:
+	rm -rf $(BUILD_DIR)
+	rm -rf $(XCFRAMEWORKS_DIR)
+
+archive_simulator:
 	xcodebuild archive \
 		-scheme "Simperium iOS" \
 		-destination "generic/platform=iOS Simulator" \
-		-archivePath $$@ \
+		-archivePath $(BUILD_DIR)/simulator.xcarchive \
 		SKIP_INSTALL=NO \
 		BUILD_LIBRARY_FOR_DISTRIBUTION=YES
 
-$(BUILD_DIR)/$(1).xcarchive:
+archive_ios:
 	xcodebuild archive \
-		-scheme "Simperium $(if $(filter ios,$(1)),iOS,OSX)" \
-		-destination "generic/platform=$(if $(filter ios,$(1)),iOS,macOS)" \
-		-archivePath $$@ \
+		-scheme "Simperium iOS" \
+		-destination "generic/platform=iOS" \
+		-archivePath $(BUILD_DIR)/ios.xcarchive \
 		SKIP_INSTALL=NO \
 		BUILD_LIBRARY_FOR_DISTRIBUTION=YES
 
-$(BUILD_DIR)/ios_all.xcarchive: $(BUILD_DIR)/ios.xcarchive $(BUILD_DIR)/simulator.xcarchive
-	@touch $$@
+archive_macos:
+	xcodebuild archive \
+		-scheme "Simperium OSX" \
+		-destination "generic/platform=macOS" \
+		-archivePath $(BUILD_DIR)/macos.xcarchive \
+		SKIP_INSTALL=NO \
+		BUILD_LIBRARY_FOR_DISTRIBUTION=YES
 
-$(XCFRAMEWORKS_DIR)/$(LIB_NAME)-$(1).xcframework: $(BUILD_DIR)/$(1).xcarchive
-	@mkdir -p $(XCFRAMEWORKS_DIR)
-	xcodebuild -create-xcframework \
-		-framework $(BUILD_DIR)/$(1).xcarchive/Products/Library/Frameworks/$(FRAMEWORK_NAME) \
-		-output $$@
+archive_all: archive_simulator archive_ios archive_macos
 
-$(XCFRAMEWORKS_DIR)/$(LIB_NAME)-ios.xcframework: $(BUILD_DIR)/ios_all.xcarchive
+$(XCFRAMEWORKS_DIR)/$(LIB_NAME).xcframework: archive_all
 	@mkdir -p $(XCFRAMEWORKS_DIR)
 	xcodebuild -create-xcframework \
 		-framework $(BUILD_DIR)/ios.xcarchive/Products/Library/Frameworks/$(FRAMEWORK_NAME) \
 		-framework $(BUILD_DIR)/simulator.xcarchive/Products/Library/Frameworks/$(FRAMEWORK_NAME) \
-		-output $$@
-
-$(XCFRAMEWORKS_DIR)/$(LIB_NAME)-macos.xcframework: $(BUILD_DIR)/macos.xcarchive
-	@mkdir -p $(XCFRAMEWORKS_DIR)
-	xcodebuild -create-xcframework \
 		-framework $(BUILD_DIR)/macos.xcarchive/Products/Library/Frameworks/$(FRAMEWORK_NAME) \
-		-output $$@
+		-output $@
 
-$(XCFRAMEWORKS_DIR)/$(LIB_NAME)-$(1).xcframework.zip: $(XCFRAMEWORKS_DIR)/$(LIB_NAME)-$(1).xcframework
+$(XCFRAMEWORKS_DIR)/$(LIB_NAME).xcframework.zip: $(XCFRAMEWORKS_DIR)/$(LIB_NAME).xcframework
 	@mkdir -p $(XCFRAMEWORKS_DIR)
-	zip -r $$@ $$<
-endef
+	codesign --timestamp -s $(CODE_SIGNING_IDENTITY) $<
+	zip -r $@ $<
+	@echo "Checksum for $(LIB_NAME).xcframework.zip:"
+	@swift package compute-checksum $@
 
-$(eval $(call BUILD_XCFRAMEWORK,ios))
-$(eval $(call BUILD_XCFRAMEWORK,macos))
-
-build_all: build_xcframework_ios build_xcframework_macos
+create_xcframework: clean $(XCFRAMEWORKS_DIR)/$(LIB_NAME).xcframework.zip

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ IOS_SCHEME := $(LIB_NAME)
 MACOS_SCHEME := $(LIB_NAME)-OSX
 
 define BUILD_XCFRAMEWORK
-build_xcframework_$(1): $(XCFRAMEWORKS_DIR)/$(LIB_NAME)-$(1).xcframework
+build_xcframework_$(1): $(XCFRAMEWORKS_DIR)/$(LIB_NAME)-$(1).xcframework.zip
 
 $(BUILD_DIR)/$(1).xcarchive:
 	xcodebuild archive \
@@ -22,6 +22,10 @@ $(XCFRAMEWORKS_DIR)/$(LIB_NAME)-$(1).xcframework: $(BUILD_DIR)/$(1).xcarchive
 	xcodebuild -create-xcframework \
 		-framework $(BUILD_DIR)/$(1).xcarchive/Products/Library/Frameworks/$(FRAMEWORK_NAME) \
 		-output $$@
+
+$(XCFRAMEWORKS_DIR)/$(LIB_NAME)-$(1).xcframework.zip: $(XCFRAMEWORKS_DIR)/$(LIB_NAME)-$(1).xcframework
+	@mkdir -p $(XCFRAMEWORKS_DIR)
+	zip -r $$@ $$<
 endef
 
 $(eval $(call BUILD_XCFRAMEWORK,ios))

--- a/Package.swift
+++ b/Package.swift
@@ -2,30 +2,19 @@
 import PackageDescription
 
 let tag = "v1.9.1-beta.1"
-let baseArtifactURL = "https://github.com/Simperium/simperium-ios/releases/download/\(tag)"
 
 let package = Package(
     name: "Simperium",
     products: [
-        .library(name: "Simperium", targets: ["SimperiumWrapper"]),
+        .library(name: "Simperium", targets: ["Simperium"])
     ],
     targets: [
-        .target(
-            name: "SimperiumWrapper",
-            dependencies: [
-                .target(name: "Simperium", condition: .when(platforms: [.iOS])),
-                .target(name: "Simperium_macOS", condition: .when(platforms: [.macOS]))
-            ]
-        ),
+        // SwiftPM requires packages to have at least one buildable target.
+        .target(name: "Dummy"),
         .binaryTarget(
             name: "Simperium",
-            url: "\(baseArtifactURL)/Simperium-ios.xcframework.zip",
-            checksum: "0dd9f439a7c0f9af7ed42945eb0d83cdeb7cc9f3e8495e2604145c15896a9525"
-        ),
-        .binaryTarget(
-            name: "Simperium_macOS",
-            url: "\(baseArtifactURL)/Simperium-macos.xcframework.zip",
-            checksum: "ae4da609094c0679ddc80b06067e08555c5e1674cf68d16072c492d537d3f287"
+            url: "https://github.com/Simperium/simperium-ios/releases/download/\(tag)/Simperium.xcframework.zip",
+            checksum: "f6eac1b33f47e9f126e8444c8e157bf22dea7b66e9a6d6ecd50e4a79820ada35"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,7 +1,7 @@
 // swift-tools-version:5.10
 import PackageDescription
 
-let tag = "v1.9.1-beta.1"
+let tag = "v1.9.1-beta.2"
 
 let package = Package(
     name: "Simperium",
@@ -14,7 +14,7 @@ let package = Package(
         .binaryTarget(
             name: "Simperium",
             url: "https://github.com/Simperium/simperium-ios/releases/download/\(tag)/Simperium.xcframework.zip",
-            checksum: "f6eac1b33f47e9f126e8444c8e157bf22dea7b66e9a6d6ecd50e4a79820ada35"
+            checksum: "159842b63ab14ed1615fcace752c57b2633b3d3be6fadd4f643a1c8323b70e48"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,7 +1,7 @@
 // swift-tools-version:5.10
 import PackageDescription
 
-let tag = "v1.9.1-beta.2"
+let version = "v1.9.1-beta.2"
 
 let package = Package(
     name: "Simperium",
@@ -13,7 +13,7 @@ let package = Package(
         .target(name: "Dummy"),
         .binaryTarget(
             name: "Simperium",
-            url: "https://github.com/Simperium/simperium-ios/releases/download/\(tag)/Simperium.xcframework.zip",
+            url: "https://github.com/Simperium/simperium-ios/releases/download/\(version)/Simperium.xcframework.zip",
             checksum: "159842b63ab14ed1615fcace752c57b2633b3d3be6fadd4f643a1c8323b70e48"
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,9 @@
 // swift-tools-version:5.10
 import PackageDescription
 
+let tag = "v1.9.1-beta.1"
+let baseArtifactURL = "https://github.com/Simperium/simperium-ios/releases/download/\(tag)"
+
 let package = Package(
     name: "Simperium",
     products: [
@@ -16,11 +19,13 @@ let package = Package(
         ),
         .binaryTarget(
             name: "Simperium",
-            path: ".build/xcframeworks/Simperium-ios.xcframework"
+            url: "\(baseArtifactURL)/Simperium-ios.xcframework.zip",
+            checksum: "0dd9f439a7c0f9af7ed42945eb0d83cdeb7cc9f3e8495e2604145c15896a9525"
         ),
         .binaryTarget(
             name: "Simperium_macOS",
-            path: ".build/xcframeworks/Simperium-macos.xcframework"
+            url: "\(baseArtifactURL)/Simperium-macos.xcframework.zip",
+            checksum: "ae4da609094c0679ddc80b06067e08555c5e1674cf68d16072c492d537d3f287"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.10
+import PackageDescription
+
+let package = Package(
+    name: "Simperium",
+    products: [
+        .library(name: "Simperium", targets: ["SimperiumWrapper"]),
+    ],
+    targets: [
+        .target(
+            name: "SimperiumWrapper",
+            dependencies: [
+                .target(name: "Simperium", condition: .when(platforms: [.iOS])),
+                .target(name: "Simperium_macOS", condition: .when(platforms: [.macOS]))
+            ]
+        ),
+        .binaryTarget(
+            name: "Simperium",
+            path: ".build/xcframeworks/Simperium-ios.xcframework"
+        ),
+        .binaryTarget(
+            name: "Simperium_macOS",
+            path: ".build/xcframeworks/Simperium-macos.xcframework"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ This is the recommended mode of integration.
 
 ### CocoaPods
 
+Simperium still supports integrating with CocoaPods, though [because CocoaPods is going to be read-only soon and not accept new pod versions](https://blog.cocoapods.org/CocoaPods-Specs-Repo/) we anticipate this support won't last in the long run and if possible we don't recommend using it to integrate Simperium anymore.
+
 There are two pods: `Simperium` for iOS and `Simperium-OSX` for macOS.
 
 ### Manually

--- a/README.md
+++ b/README.md
@@ -11,7 +11,27 @@ You can [sign up](http://simperium.com) for a hosted version of Simperium. There
 
 Adding Simperium to your project
 --------------------------------
-The easiest way to add Simperium is to [download the latest release](https://github.com/Simperium/simperium-ios/releases/latest). Unzip the source code somewhere convenient.
+
+### Swift Package Manager
+
+From version 1.9.1, the project support integrating via Swift Package Manager.
+This is the recommended mode of integration.
+
+```swift
+.package(url: "https://github.com/Simperium/simperium-ios", from: "1.9.1-beta.2")
+```
+
+Notice that Simperium is distributed as a binary target and that only tagged versions have the binary attached.
+As such **you must point to a tagged version**.
+If you point to a commit or branch, SwiftPM will checkout the source for it without issue, but the binary it will download will be the one for the tag specified in the `Package.swift` it checks out; SwiftPM does not build the binary target for you.
+
+### CocoaPods
+
+There are two pods: `Simperium` for iOS and `Simperium-OSX` for macOS.
+
+### Manually
+
+[Download the latest release](https://github.com/Simperium/simperium-ios/releases/latest). Unzip the source code somewhere convenient.
 
 Then, drag and drop Simperium.xcodeproj into your application's project, and add Simperium.framework in your target's Build Phase tab (under Link Binary with Libraries). You'll still need to [add some dependencies](http://simperium.com/docs/ios/#add).
 

--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ Building a new release
 The release process is not yet automated.
 
 1. Ensure `SPLibraryVersion` in `Simperium/SPEnvironment.m` has the version number of the new release you want to publish.
-1. Ensure the `tag` in `Package.swift` has the same value.
-1. Run `make` to create the XCFramework for SwiftPM, notice the checksum value it prints in the output.
+1. Ensure the `version` in `Package.swift` has the same value.
+1. Run `make` to create the XCFramework ZIP archive for SwiftPM, notice the checksum value it prints in the output.
 1. Update the `checksum` in `Package.swift` with the checksum value from the step above.
 1. Validate the CocoaPods specs with `pod lib lint --allow-warnings`.
-1. Commit, tag the repo, and push.
-1. Create a new GitHub release from the tag and add the ZIP at `.build/xcframework/Simperium.xcframework.zip` as an artifact.
-1. Publish the GitHub release. This will make the new version available via Swift Package Manager.
+1. Commit and push the changes, ideally via a PR title "Release x.y.z"
+1. Create a new GitHub Release, set it up to create a tag with the same name as the new version number, and add the ZIP at `.build/xcframework/Simperium.xcframework.zip` as an artifact.
+1. Publish the GitHub release. This will create the Git tag and make the new version available via Swift Package Manager.
 1. Publish a new CocoaPods version for iOS with `pod trunk push Simperium.podspec` and for macOS with `pod trunk push Simperium-OSX.podspec`.
 
 License

--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ Folder structure
 
 **Helpers**. Exporter, keychain, etc.
 
+Building a new release
+----------------------
+
+The release process is not yet automated.
+
+1. Ensure `SPLibraryVersion` in `Simperium/SPEnvironment.m` has the version number of the new release you want to publish.
+1. Ensure the `tag` in `Package.swift` has the same value.
+3. Run `make` to create the XCFramework for SwiftPM, notice the checksum value it prints in the output.
+4. Update the `checksum` in `Package.swift` with the checksum value from the step above.
+5. Validate the CocoaPods specs with `pod lib lint --allow-warnings`.
+6. Commit, tag the repo, and push.
+7. Create a new GitHub release from the tag and add the ZIP at `.build/xcframework/Simperium.xcframework.zip` as an artifact.
+8. Publish the GitHub release. This will make the new version available via Swift Package Manager.
+9. Publish a new CocoaPods version for iOS with `pod trunk push Simperium.podspec` and for macOS with `pod trunk push Simperium-OSX.podspec`.
+
 License
 -------
 The Simperium iOS library is available for free and commercial use under the MIT license.

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ This is the recommended mode of integration.
 .package(url: "https://github.com/Simperium/simperium-ios", from: "1.9.1-beta.2")
 ```
 
-Notice that Simperium is distributed as a binary target and that only tagged versions have the binary attached.
-As such **you must point to a tagged version**.
-If you point to a commit or branch, SwiftPM will checkout the source for it without issue, but the binary it will download will be the one for the tag specified in the `Package.swift` it checks out; SwiftPM does not build the binary target for you.
+> [!IMPORTANT]
+> Notice that Simperium is distributed as a binary target and that only tagged versions have the binary attached.
+> As such **you must point to a tagged version**.
+> If you point to a commit or branch, SwiftPM will checkout the source for it without issue, but the binary it will download will be the one for the tag specified in the `Package.swift` it checks out; SwiftPM does not build the binary target for you.
 
 ### CocoaPods
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Everything works pretty much the same on OSX. Some changes are noted [in the onl
 
 Releases
 --------
-The master branch always has the latest stable release, and is tagged. Simperium is used by hundreds of thousands of people across many different apps and devices, and is considered production-ready.
+The `main` branch always has the latest stable release, and is tagged. Simperium is used by hundreds of thousands of people across many different apps and devices, and is considered production-ready.
 
-The develop branch has an ongoing development build (not intended for production use).
+The `develop` branch has an ongoing development build (not intended for production use).
 
 Folder structure
 ----------------

--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ The release process is not yet automated.
 
 1. Ensure `SPLibraryVersion` in `Simperium/SPEnvironment.m` has the version number of the new release you want to publish.
 1. Ensure the `tag` in `Package.swift` has the same value.
-3. Run `make` to create the XCFramework for SwiftPM, notice the checksum value it prints in the output.
-4. Update the `checksum` in `Package.swift` with the checksum value from the step above.
-5. Validate the CocoaPods specs with `pod lib lint --allow-warnings`.
-6. Commit, tag the repo, and push.
-7. Create a new GitHub release from the tag and add the ZIP at `.build/xcframework/Simperium.xcframework.zip` as an artifact.
-8. Publish the GitHub release. This will make the new version available via Swift Package Manager.
-9. Publish a new CocoaPods version for iOS with `pod trunk push Simperium.podspec` and for macOS with `pod trunk push Simperium-OSX.podspec`.
+1. Run `make` to create the XCFramework for SwiftPM, notice the checksum value it prints in the output.
+1. Update the `checksum` in `Package.swift` with the checksum value from the step above.
+1. Validate the CocoaPods specs with `pod lib lint --allow-warnings`.
+1. Commit, tag the repo, and push.
+1. Create a new GitHub release from the tag and add the ZIP at `.build/xcframework/Simperium.xcframework.zip` as an artifact.
+1. Publish the GitHub release. This will make the new version available via Swift Package Manager.
+1. Publish a new CocoaPods version for iOS with `pod trunk push Simperium.podspec` and for macOS with `pod trunk push Simperium-OSX.podspec`.
 
 License
 -------

--- a/Simperium.xcodeproj/project.pbxproj
+++ b/Simperium.xcodeproj/project.pbxproj
@@ -293,7 +293,7 @@
 		B5CAA5CD1CAAED3D006FE048 /* DiffMatchPatchCFUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 264CD968135DFE7E00C51BAD /* DiffMatchPatchCFUtilities.h */; };
 		B5CAA5CE1CAAED3D006FE048 /* MinMaxMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 264CD969135DFE7E00C51BAD /* MinMaxMacros.h */; };
 		B5CAA5CF1CAAED3D006FE048 /* NSMutableDictionary+DMPExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 264CD96A135DFE7E00C51BAD /* NSMutableDictionary+DMPExtensions.h */; };
-		B5CAA5D01CAAED3D006FE048 /* NSDate+Simperium.h in Headers */ = {isa = PBXBuildFile; fileRef = 26E83DA81399D05D00195758 /* NSDate+Simperium.h */; };
+		B5CAA5D01CAAED3D006FE048 /* NSDate+Simperium.h in Headers */ = {isa = PBXBuildFile; fileRef = 26E83DA81399D05D00195758 /* NSDate+Simperium.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B5CAA5D11CAAED3D006FE048 /* NSString+JavaSubstring.h in Headers */ = {isa = PBXBuildFile; fileRef = 264CD96C135DFE7E00C51BAD /* NSString+JavaSubstring.h */; };
 		B5CAA5D21CAAED3D006FE048 /* NSString+UnicharUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 264CD96E135DFE7E00C51BAD /* NSString+UnicharUtilities.h */; };
 		B5CAA5D31CAAED3D006FE048 /* NSString+UriCompatibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 264CD970135DFE7E00C51BAD /* NSString+UriCompatibility.h */; };
@@ -337,7 +337,7 @@
 		B5CAA5FE1CAAED3D006FE048 /* NSArray+Simperium.h in Headers */ = {isa = PBXBuildFile; fileRef = 1854D50D1799F6D2006C4211 /* NSArray+Simperium.h */; };
 		B5CAA5FF1CAAED3D006FE048 /* SPBucket+Internals.h in Headers */ = {isa = PBXBuildFile; fileRef = B5AC545C1857917800608CAC /* SPBucket+Internals.h */; };
 		B5CAA6001CAAED3D006FE048 /* SPMemberJSONList.h in Headers */ = {isa = PBXBuildFile; fileRef = 46DD15C8179A6F4B0093678C /* SPMemberJSONList.h */; };
-		B5CAA6011CAAED3D006FE048 /* SPAuthenticationValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = 466EB41217BC45F5005F7599 /* SPAuthenticationValidator.h */; };
+		B5CAA6011CAAED3D006FE048 /* SPAuthenticationValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = 466EB41217BC45F5005F7599 /* SPAuthenticationValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B5CAA6031CAAED3D006FE048 /* SPManagedObject+Internals.h in Headers */ = {isa = PBXBuildFile; fileRef = B5F65F791847DE0100CEF48D /* SPManagedObject+Internals.h */; };
 		B5CAA6041CAAED3D006FE048 /* SPProcessorConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 460A505D17DE96350070F02B /* SPProcessorConstants.h */; };
 		B5CAA6051CAAED3D006FE048 /* SPKeychain.h in Headers */ = {isa = PBXBuildFile; fileRef = 797D26FA19F1B72700DEF569 /* SPKeychain.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -351,7 +351,7 @@
 		B5CAA63C1CAAF1D9006FE048 /* SPAuthenticationButton.m in Sources */ = {isa = PBXBuildFile; fileRef = B5CAA6301CAAF1D9006FE048 /* SPAuthenticationButton.m */; };
 		B5CAA63D1CAAF1D9006FE048 /* SPAuthenticationButtonCell.h in Headers */ = {isa = PBXBuildFile; fileRef = B5CAA6311CAAF1D9006FE048 /* SPAuthenticationButtonCell.h */; };
 		B5CAA63E1CAAF1D9006FE048 /* SPAuthenticationButtonCell.m in Sources */ = {isa = PBXBuildFile; fileRef = B5CAA6321CAAF1D9006FE048 /* SPAuthenticationButtonCell.m */; };
-		B5CAA63F1CAAF1D9006FE048 /* SPAuthenticationTextField.h in Headers */ = {isa = PBXBuildFile; fileRef = B5CAA6331CAAF1D9006FE048 /* SPAuthenticationTextField.h */; };
+		B5CAA63F1CAAF1D9006FE048 /* SPAuthenticationTextField.h in Headers */ = {isa = PBXBuildFile; fileRef = B5CAA6331CAAF1D9006FE048 /* SPAuthenticationTextField.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B5CAA6401CAAF1D9006FE048 /* SPAuthenticationTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = B5CAA6341CAAF1D9006FE048 /* SPAuthenticationTextField.m */; };
 		B5CAA6411CAAF1D9006FE048 /* SPAuthenticationView.h in Headers */ = {isa = PBXBuildFile; fileRef = B5CAA6351CAAF1D9006FE048 /* SPAuthenticationView.h */; };
 		B5CAA6421CAAF1D9006FE048 /* SPAuthenticationView.m in Sources */ = {isa = PBXBuildFile; fileRef = B5CAA6361CAAF1D9006FE048 /* SPAuthenticationView.m */; };
@@ -365,7 +365,7 @@
 		B5CAA6511CAAF2F8006FE048 /* SPAuthenticationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5CAA64B1CAAF2F8006FE048 /* SPAuthenticationViewController.m */; };
 		B5CAA6521CAAF2F8006FE048 /* SPWebViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = B5CAA64C1CAAF2F8006FE048 /* SPWebViewController.h */; };
 		B5CAA6531CAAF2F8006FE048 /* SPWebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5CAA64D1CAAF2F8006FE048 /* SPWebViewController.m */; };
-		B5CAA6561CAAF354006FE048 /* Simperium_OSX.h in Headers */ = {isa = PBXBuildFile; fileRef = B5CAA6551CAAF354006FE048 /* Simperium_OSX.h */; };
+		B5CAA6561CAAF354006FE048 /* Simperium_OSX.h in Headers */ = {isa = PBXBuildFile; fileRef = B5CAA6551CAAF354006FE048 /* Simperium_OSX.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B5CAA6591CAAF38E006FE048 /* UIViewController+Simperium.h in Headers */ = {isa = PBXBuildFile; fileRef = B5CAA6571CAAF38E006FE048 /* UIViewController+Simperium.h */; };
 		B5CAA65A1CAAF38E006FE048 /* UIViewController+Simperium.m in Sources */ = {isa = PBXBuildFile; fileRef = B5CAA6581CAAF38E006FE048 /* UIViewController+Simperium.m */; };
 		B5CAA65D1CAAF3F6006FE048 /* UIDevice+Simperium.h in Headers */ = {isa = PBXBuildFile; fileRef = B5CAA65B1CAAF3F6006FE048 /* UIDevice+Simperium.h */; };

--- a/Simperium.xcodeproj/project.pbxproj
+++ b/Simperium.xcodeproj/project.pbxproj
@@ -137,8 +137,8 @@
 		B5CAA5011CAAB83D006FE048 /* SPAuthenticationValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = 466EB41217BC45F5005F7599 /* SPAuthenticationValidator.h */; };
 		B5CAA5031CAAB84F006FE048 /* SPManagedObject+Internals.h in Headers */ = {isa = PBXBuildFile; fileRef = B5F65F791847DE0100CEF48D /* SPManagedObject+Internals.h */; };
 		B5CAA5041CAAB85C006FE048 /* SPProcessorConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 460A505D17DE96350070F02B /* SPProcessorConstants.h */; };
-		B5CAA5051CAAB865006FE048 /* SPKeychain.h in Headers */ = {isa = PBXBuildFile; fileRef = 797D26FA19F1B72700DEF569 /* SPKeychain.h */; };
-		B5CAA5061CAAB869006FE048 /* SPKeychainQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = 797D26FC19F1B72700DEF569 /* SPKeychainQuery.h */; };
+		B5CAA5051CAAB865006FE048 /* SPKeychain.h in Headers */ = {isa = PBXBuildFile; fileRef = 797D26FA19F1B72700DEF569 /* SPKeychain.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B5CAA5061CAAB869006FE048 /* SPKeychainQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = 797D26FC19F1B72700DEF569 /* SPKeychainQuery.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B5CAA5071CAAB8DE006FE048 /* SPStorageObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 265D80131476461800002A19 /* SPStorageObserver.h */; };
 		B5CAA5081CAAB95D006FE048 /* Simperium.m in Sources */ = {isa = PBXBuildFile; fileRef = 264CD92B135DFE6D00C51BAD /* Simperium.m */; };
 		B5CAA5091CAAB961006FE048 /* SPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B5EB86991822E34F007450FF /* SPLogger.m */; };
@@ -340,8 +340,8 @@
 		B5CAA6011CAAED3D006FE048 /* SPAuthenticationValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = 466EB41217BC45F5005F7599 /* SPAuthenticationValidator.h */; };
 		B5CAA6031CAAED3D006FE048 /* SPManagedObject+Internals.h in Headers */ = {isa = PBXBuildFile; fileRef = B5F65F791847DE0100CEF48D /* SPManagedObject+Internals.h */; };
 		B5CAA6041CAAED3D006FE048 /* SPProcessorConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 460A505D17DE96350070F02B /* SPProcessorConstants.h */; };
-		B5CAA6051CAAED3D006FE048 /* SPKeychain.h in Headers */ = {isa = PBXBuildFile; fileRef = 797D26FA19F1B72700DEF569 /* SPKeychain.h */; };
-		B5CAA6061CAAED3D006FE048 /* SPKeychainQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = 797D26FC19F1B72700DEF569 /* SPKeychainQuery.h */; };
+		B5CAA6051CAAED3D006FE048 /* SPKeychain.h in Headers */ = {isa = PBXBuildFile; fileRef = 797D26FA19F1B72700DEF569 /* SPKeychain.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B5CAA6061CAAED3D006FE048 /* SPKeychainQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = 797D26FC19F1B72700DEF569 /* SPKeychainQuery.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B5CAA60E1CAAEE30006FE048 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5CAA60D1CAAEE30006FE048 /* AppKit.framework */; };
 		B5CAA6101CAAEE4E006FE048 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5CAA60F1CAAEE4E006FE048 /* Cocoa.framework */; };
 		B5CAA6121CAAEE7F006FE048 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5CAA6111CAAEE7F006FE048 /* CoreServices.framework */; };

--- a/Simperium.xcodeproj/project.pbxproj
+++ b/Simperium.xcodeproj/project.pbxproj
@@ -208,7 +208,7 @@
 		B5CAA5511CAAC237006FE048 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 264CD9B0135DFFFF00C51BAD /* CoreData.framework */; };
 		B5CAA5521CAAC23E006FE048 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 264CD8FE135DFD7A00C51BAD /* Foundation.framework */; };
 		B5CAA5541CAAC4B1006FE048 /* libicucore.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = B5CAA5531CAAC4B1006FE048 /* libicucore.tbd */; };
-		B5CAA5581CAACC30006FE048 /* Simperium_iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = B5CAA5571CAACC30006FE048 /* Simperium_iOS.h */; };
+		B5CAA5581CAACC30006FE048 /* Simperium_iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = B5CAA5571CAACC30006FE048 /* Simperium_iOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B5CAA56C1CAAED3D006FE048 /* Simperium.m in Sources */ = {isa = PBXBuildFile; fileRef = 264CD92B135DFE6D00C51BAD /* Simperium.m */; };
 		B5CAA56D1CAAED3D006FE048 /* SPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B5EB86991822E34F007450FF /* SPLogger.m */; };
 		B5CAA56E1CAAED3D006FE048 /* JSONKit+Simperium.m in Sources */ = {isa = PBXBuildFile; fileRef = B5E03D97182C115100412572 /* JSONKit+Simperium.m */; };
@@ -318,7 +318,6 @@
 		B5CAA5EA1CAAED3D006FE048 /* SPRelationship.h in Headers */ = {isa = PBXBuildFile; fileRef = B58B22E31905A1B200190E90 /* SPRelationship.h */; };
 		B5CAA5EB1CAAED3D006FE048 /* SPMemberList.h in Headers */ = {isa = PBXBuildFile; fileRef = 2622FD22147F251100C8EEB4 /* SPMemberList.h */; };
 		B5CAA5EC1CAAED3D006FE048 /* SPMemberBase64.h in Headers */ = {isa = PBXBuildFile; fileRef = 2622FD26147F251C00C8EEB4 /* SPMemberBase64.h */; };
-		B5CAA5ED1CAAED3D006FE048 /* Simperium_iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = B5CAA5571CAACC30006FE048 /* Simperium_iOS.h */; };
 		B5CAA5EE1CAAED3D006FE048 /* NSMutableDictionary+Simperium.h in Headers */ = {isa = PBXBuildFile; fileRef = 267CE8EB156C0FD20028801C /* NSMutableDictionary+Simperium.h */; };
 		B5CAA5EF1CAAED3D006FE048 /* SPDiffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 267CE8F2156C0FD20028801C /* SPDiffer.h */; };
 		B5CAA5F01CAAED3D006FE048 /* NSError+Simperium.h in Headers */ = {isa = PBXBuildFile; fileRef = B5F4C84318FC1B04009F8643 /* NSError+Simperium.h */; };
@@ -362,7 +361,7 @@
 		B5CAA6461CAAF1D9006FE048 /* SPAuthenticationWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5CAA63A1CAAF1D9006FE048 /* SPAuthenticationWindowController.m */; };
 		B5CAA64E1CAAF2F8006FE048 /* SPAuthenticationButton.h in Headers */ = {isa = PBXBuildFile; fileRef = B5CAA6481CAAF2F8006FE048 /* SPAuthenticationButton.h */; };
 		B5CAA64F1CAAF2F8006FE048 /* SPAuthenticationButton.m in Sources */ = {isa = PBXBuildFile; fileRef = B5CAA6491CAAF2F8006FE048 /* SPAuthenticationButton.m */; };
-		B5CAA6501CAAF2F8006FE048 /* SPAuthenticationViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = B5CAA64A1CAAF2F8006FE048 /* SPAuthenticationViewController.h */; };
+		B5CAA6501CAAF2F8006FE048 /* SPAuthenticationViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = B5CAA64A1CAAF2F8006FE048 /* SPAuthenticationViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B5CAA6511CAAF2F8006FE048 /* SPAuthenticationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5CAA64B1CAAF2F8006FE048 /* SPAuthenticationViewController.m */; };
 		B5CAA6521CAAF2F8006FE048 /* SPWebViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = B5CAA64C1CAAF2F8006FE048 /* SPWebViewController.h */; };
 		B5CAA6531CAAF2F8006FE048 /* SPWebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5CAA64D1CAAF2F8006FE048 /* SPWebViewController.m */; };
@@ -570,6 +569,8 @@
 		26F4BBCD13DCFDA700B8AC56 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
 		26F4BBCF13DCFDB000B8AC56 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
 		26F4BBD313DCFDC100B8AC56 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
+		3F128CEB2DFC260300D1B006 /* ios.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = ios.modulemap; sourceTree = "<group>"; };
+		3F128CEC2DFC260F00D1B006 /* macos.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = macos.modulemap; sourceTree = "<group>"; };
 		460A505C17DE96350070F02B /* SPProcessorConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPProcessorConstants.m; sourceTree = "<group>"; };
 		460A505D17DE96350070F02B /* SPProcessorConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPProcessorConstants.h; sourceTree = "<group>"; };
 		466EB41017BC45F5005F7599 /* SPAuthenticationConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPAuthenticationConfiguration.h; sourceTree = "<group>"; };
@@ -996,6 +997,8 @@
 				265D80061475C2CE00002A19 /* Categories */,
 				B5F4FE6818A3D7B8006F50C5 /* Simperium.podspec */,
 				B5CAA65F1CAAF881006FE048 /* Simperium-OSX.podspec */,
+				3F128CEB2DFC260300D1B006 /* ios.modulemap */,
+				3F128CEC2DFC260F00D1B006 /* macos.modulemap */,
 			);
 			path = Simperium;
 			sourceTree = "<group>";
@@ -1520,7 +1523,6 @@
 				B5CAA5EB1CAAED3D006FE048 /* SPMemberList.h in Headers */,
 				B5CAA5EC1CAAED3D006FE048 /* SPMemberBase64.h in Headers */,
 				B5FC08BD1D662D5300045DB9 /* TrustKit.h in Headers */,
-				B5CAA5ED1CAAED3D006FE048 /* Simperium_iOS.h in Headers */,
 				B5CAA5EE1CAAED3D006FE048 /* NSMutableDictionary+Simperium.h in Headers */,
 				B5CAA5EF1CAAED3D006FE048 /* SPDiffer.h in Headers */,
 				B5CAA5F01CAAED3D006FE048 /* NSError+Simperium.h in Headers */,
@@ -2128,6 +2130,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 1.1.7;
+				MODULEMAP_FILE = $SRCROOT/Simperium/ios.modulemap;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.simperium;
 				PRODUCT_NAME = Simperium;
@@ -2179,6 +2182,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 1.1.7;
+				MODULEMAP_FILE = $SRCROOT/Simperium/ios.modulemap;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.simperium;
 				PRODUCT_NAME = Simperium;
@@ -2236,6 +2240,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MARKETING_VERSION = 1.1.7;
+				MODULEMAP_FILE = $SRCROOT/Simperium/macos.modulemap;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.simperium;
 				PRODUCT_NAME = Simperium;
@@ -2288,6 +2293,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MARKETING_VERSION = 1.1.7;
+				MODULEMAP_FILE = $SRCROOT/Simperium/macos.modulemap;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.simperium;
 				PRODUCT_NAME = Simperium;

--- a/Simperium/Simperium+Internals.h
+++ b/Simperium/Simperium+Internals.h
@@ -34,7 +34,6 @@
 @property (nonatomic, strong) id<SPNetworkInterface>    network;
 @property (nonatomic, strong) SPRelationshipResolver    *relationshipResolver;
 @property (nonatomic, strong) SPReachability            *reachability;
-@property (nonatomic, strong) SPUser                    *user;
 @property (nonatomic,   copy) NSString                  *clientID;
 @property (nonatomic,   copy) NSString                  *appID;
 @property (nonatomic,   copy) NSString                  *APIKey;

--- a/Simperium/Simperium.h
+++ b/Simperium/Simperium.h
@@ -186,7 +186,7 @@ typedef void (^SimperiumSignoutCompletion)(void);
 @property (nonatomic, readwrite, assign) BOOL validatesObjects;
 
 // Returns the currently authenticated Simperium user.
-@property (nonatomic, readonly, strong, nullable) SPUser *user;
+@property (nonatomic, readwrite, strong, nullable) SPUser *user;
 
 // The full URL used to communicate with Simperium.
 @property (nonatomic, readonly, copy) NSString *appURL;
@@ -239,6 +239,9 @@ typedef void (^SimperiumSignoutCompletion)(void);
 #else
 @property (nonatomic, readwrite, weak) NSWindow *window;
 #endif
+
+- (void)authenticationDidSucceedForUsername:(NSString *)username
+                                      token:(NSString *)token;
 
 @end
 

--- a/Simperium/ios.modulemap
+++ b/Simperium/ios.modulemap
@@ -1,0 +1,5 @@
+framework module Simperium {
+    umbrella header "Simperium_iOS.h"
+    export *
+    module * { export * }
+}

--- a/Simperium/macos.modulemap
+++ b/Simperium/macos.modulemap
@@ -1,0 +1,5 @@
+framework module Simperium {
+    umbrella header "Simperium_OSX.h"
+    export *
+    module * { export * }
+}


### PR DESCRIPTION
https://linear.app/a8c/issue/AINFRA-757

Used IRL in https://github.com/Automattic/simplenote-ios/pull/1716 and https://github.com/Automattic/simplenote-macos/pull/1243

Using the XCFramework was simpler than detangling the UIKit and AppKit sources to avoid iOS vs macOS build issues.

The downside is that we need to host the XCFramework somewhere. If this was a project in ongoing development, I'd recommend a setup like the one we have [in mobile-gutenberg](https://github.com/wordpress-mobile/gutenberg-mobile/blob/64b1e26ecc261f48e00ebf07e2f3d235f62c41ab/ios-xcframework/build.sh). But given this gets touched rarely, I've gone with manually uploading the ZIP to a GitHub release, https://github.com/Simperium/simperium-ios/releases/tag/v1.9.1-beta.2

To verify the process, checkout locally and run `make`.